### PR TITLE
docs: update for testmode and customer creation changes

### DIFF
--- a/docs/Checkouts.md
+++ b/docs/Checkouts.md
@@ -40,25 +40,14 @@ $checkout = $user->checkout()
     );
 ```
 
-## Testmode
-
-```php
-$checkout = $user->checkout()
-    ->withItems(collect(['product_abc123']))
-    ->inTestmode()
-    ->create(
-        redirectUrlSuccess: 'https://your-app.com/success',
-        redirectUrlCanceled: 'https://your-app.com/canceled',
-    );
-```
-
 ## How it works
 
 The checkout flow:
 
-1. Your app creates a checkout session via the Vatly API
+1. Your app creates a checkout session via the Vatly API (customer is created automatically if needed)
 2. The customer is redirected to Vatly's hosted payment page
 3. After payment, the customer returns to your `redirectUrlSuccess`
 4. Vatly sends a webhook to confirm the payment (see [Webhooks](/packages/laravel/webhooks))
+5. If this was a new customer, the customer ID is synced to your local database via webhook
 
 The redirect URLs default to the values in your `vatly.php` config but can be overridden per checkout.

--- a/docs/Customers.md
+++ b/docs/Customers.md
@@ -1,6 +1,6 @@
 # Customers
 
-Every billable model can be linked to a Vatly customer. The customer is created automatically when needed, or you can create one explicitly.
+Every billable model can be linked to a Vatly customer. Customers are created automatically by Vatly during checkout and synced to your application via webhooks. You can also create customers explicitly if needed.
 
 ## Creating a customer
 
@@ -41,3 +41,9 @@ The `vatly_id` column on your billable model stores the Vatly customer identifie
 3. Returns the customer response
 
 If the user already has a `vatly_id`, calling `createAsVatlyCustomer()` will throw a `CustomerAlreadyCreatedException`.
+
+## Automatic customer creation
+
+When a user starts a checkout without an existing Vatly customer ID, Vatly creates the customer automatically during the checkout flow. The customer ID is synced back to your application via webhooks.
+
+This means you don't need to call `createAsVatlyCustomer()` before starting a checkout - just redirect the user directly.

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,10 +41,11 @@ VATLY_REDIRECT_URL_CANCELED=https://your-app.com/checkout/canceled
 | `api_url` | `VATLY_API_URL` | `https://api.vatly.com` |
 | `api_version` | `VATLY_API_VERSION` | `v1` |
 | `webhook_secret` | `VATLY_WEBHOOK_SECRET` | (required for webhooks) |
-| `testmode` | `VATLY_TESTMODE` | `false` |
 | `billable_model` | `VATLY_BILLABLE_MODEL` | `App\Models\User` |
 | `redirect_url_success` | `VATLY_REDIRECT_URL_SUCCESS` | (required for checkouts) |
 | `redirect_url_canceled` | `VATLY_REDIRECT_URL_CANCELED` | (required for checkouts) |
+
+> **Note:** Testmode is automatically determined from your API key prefix. Keys starting with `test_` use testmode; keys starting with `live_` use production mode. No configuration needed.
 
 ## Database setup
 


### PR DESCRIPTION
Updates documentation to reflect recent package changes:

- **Testmode**: Now inferred from API key prefix (`test_` vs `live_`), no config needed
- **Customer creation**: Customers are created automatically during checkout, no need to pre-create
- Removed `inTestmode()` documentation (method no longer exists)

Related to vatly-laravel PR #9