### PR TITLE
feat: rename updatePaymentMethodUrl → createBillingUpdateLink

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "illuminate/http": "^11.0|^12.0",
         "illuminate/routing": "^11.0|^12.0",
         "illuminate/support": "^11.0|^12.0",
-        "vatly/vatly-fluent-php": "0.4.0-alpha.2"
+        "vatly/vatly-fluent-php": "0.4.0-alpha.3"
     },
     "require-dev": {
         "larastan/larastan": "^3.9",

--- a/docs/Subscriptions.md
+++ b/docs/Subscriptions.md
@@ -47,11 +47,13 @@ The actual cancellation is processed via webhooks. Depending on the Vatly config
 - End immediately (`SubscriptionCanceledImmediately` event)
 - Enter a grace period (`SubscriptionCanceledWithGracePeriod` event)
 
-## Updating payment method
+## Updating billing details
 
 ```php
-// Get a URL where the customer can update their payment method
-$url = $user->subscription()->updatePaymentMethodUrl();
+// Create a signed URL where the customer can update their billing details
+// (address, VAT number, company name). Going through the hosted flow also
+// refreshes the Mollie mandate as a side effect.
+$url = $user->subscription()->createBillingUpdateLink();
 
 return redirect($url);
 ```

--- a/src/Models/Subscription.php
+++ b/src/Models/Subscription.php
@@ -169,8 +169,8 @@ class Subscription extends Model implements SubscriptionInterface
      */
     public function createBillingUpdateLink(array $prefillData = []): string
     {
-        /** @var \Vatly\Fluent\Actions\CreateBillingUpdateLink $action */
-        $action = app()->make(\Vatly\Fluent\Actions\CreateBillingUpdateLink::class);
+        /** @var \Vatly\Fluent\Actions\CreateSubscriptionBillingUpdateLink $action */
+        $action = app()->make(\Vatly\Fluent\Actions\CreateSubscriptionBillingUpdateLink::class);
         $response = $action->execute($this->vatly_id, $prefillData);
 
         return $response->href;

--- a/src/Models/Subscription.php
+++ b/src/Models/Subscription.php
@@ -159,14 +159,18 @@ class Subscription extends Model implements SubscriptionInterface
     }
 
     /**
-     * Get the URL where the customer can update their payment method.
+     * Create a signed URL where the customer can update the billing details for this
+     * subscription (billing address, VAT number, company name).
+     *
+     * Each call creates a fresh time-bounded link (30-minute TTL by default), so generate
+     * one per email/redirect rather than reusing.
      *
      * @param array<string, mixed> $prefillData
      */
-    public function updatePaymentMethodUrl(array $prefillData = []): string
+    public function createBillingUpdateLink(array $prefillData = []): string
     {
-        /** @var \Vatly\Fluent\Actions\GetPaymentMethodUpdateUrl $action */
-        $action = app()->make(\Vatly\Fluent\Actions\GetPaymentMethodUpdateUrl::class);
+        /** @var \Vatly\Fluent\Actions\CreateBillingUpdateLink $action */
+        $action = app()->make(\Vatly\Fluent\Actions\CreateBillingUpdateLink::class);
         $response = $action->execute($this->vatly_id, $prefillData);
 
         return $response->href;

--- a/src/VatlyServiceProvider.php
+++ b/src/VatlyServiceProvider.php
@@ -10,7 +10,7 @@ use Vatly\Fluent\Actions\CreateCheckout;
 use Vatly\Fluent\Actions\CreateCustomer;
 use Vatly\Fluent\Actions\GetCheckout;
 use Vatly\Fluent\Actions\GetCustomer;
-use Vatly\Fluent\Actions\CreateBillingUpdateLink;
+use Vatly\Fluent\Actions\CreateSubscriptionBillingUpdateLink;
 use Vatly\Fluent\Actions\GetSubscription;
 use Vatly\Fluent\Actions\SwapSubscriptionPlan;
 use Vatly\API\VatlyApiClient;
@@ -83,7 +83,7 @@ class VatlyServiceProvider extends ServiceProvider
             CreateCheckout::class,
             GetCheckout::class,
             GetSubscription::class,
-            CreateBillingUpdateLink::class,
+            CreateSubscriptionBillingUpdateLink::class,
             CancelSubscription::class,
             SwapSubscriptionPlan::class,
         ];

--- a/src/VatlyServiceProvider.php
+++ b/src/VatlyServiceProvider.php
@@ -10,7 +10,7 @@ use Vatly\Fluent\Actions\CreateCheckout;
 use Vatly\Fluent\Actions\CreateCustomer;
 use Vatly\Fluent\Actions\GetCheckout;
 use Vatly\Fluent\Actions\GetCustomer;
-use Vatly\Fluent\Actions\GetPaymentMethodUpdateUrl;
+use Vatly\Fluent\Actions\CreateBillingUpdateLink;
 use Vatly\Fluent\Actions\GetSubscription;
 use Vatly\Fluent\Actions\SwapSubscriptionPlan;
 use Vatly\API\VatlyApiClient;
@@ -83,7 +83,7 @@ class VatlyServiceProvider extends ServiceProvider
             CreateCheckout::class,
             GetCheckout::class,
             GetSubscription::class,
-            GetPaymentMethodUpdateUrl::class,
+            CreateBillingUpdateLink::class,
             CancelSubscription::class,
             SwapSubscriptionPlan::class,
         ];

--- a/tests/Models/SubscriptionCreateBillingUpdateLinkTest.php
+++ b/tests/Models/SubscriptionCreateBillingUpdateLinkTest.php
@@ -6,7 +6,7 @@ namespace Vatly\Laravel\Tests\Models;
 
 use Mockery;
 use Vatly\API\Types\Link;
-use Vatly\Fluent\Actions\CreateBillingUpdateLink;
+use Vatly\Fluent\Actions\CreateSubscriptionBillingUpdateLink;
 use Vatly\Laravel\Models\Subscription;
 use Vatly\Laravel\Tests\BaseTestCase;
 
@@ -23,13 +23,13 @@ class SubscriptionCreateBillingUpdateLinkTest extends BaseTestCase
     {
         $expectedUrl = 'https://checkout.vatly.com/billing-update/abc123';
 
-        $mockAction = Mockery::mock(CreateBillingUpdateLink::class);
+        $mockAction = Mockery::mock(CreateSubscriptionBillingUpdateLink::class);
         $mockAction->shouldReceive('execute')
             ->once()
             ->with('subscription_test123', [])
             ->andReturn(new Link($expectedUrl, 'text/html'));
 
-        app()->instance(CreateBillingUpdateLink::class, $mockAction);
+        app()->instance(CreateSubscriptionBillingUpdateLink::class, $mockAction);
 
         $subscription = new Subscription(['vatly_id' => 'subscription_test123']);
         $url = $subscription->createBillingUpdateLink();
@@ -42,13 +42,13 @@ class SubscriptionCreateBillingUpdateLinkTest extends BaseTestCase
     {
         $prefillData = ['billingAddress' => ['city' => 'Amsterdam']];
 
-        $mockAction = Mockery::mock(CreateBillingUpdateLink::class);
+        $mockAction = Mockery::mock(CreateSubscriptionBillingUpdateLink::class);
         $mockAction->shouldReceive('execute')
             ->once()
             ->with('subscription_test123', $prefillData)
             ->andReturn(new Link('https://checkout.vatly.com/billing-update', 'text/html'));
 
-        app()->instance(CreateBillingUpdateLink::class, $mockAction);
+        app()->instance(CreateSubscriptionBillingUpdateLink::class, $mockAction);
 
         $subscription = new Subscription(['vatly_id' => 'subscription_test123']);
         $url = $subscription->createBillingUpdateLink($prefillData);

--- a/tests/Models/SubscriptionCreateBillingUpdateLinkTest.php
+++ b/tests/Models/SubscriptionCreateBillingUpdateLinkTest.php
@@ -6,11 +6,11 @@ namespace Vatly\Laravel\Tests\Models;
 
 use Mockery;
 use Vatly\API\Types\Link;
-use Vatly\Fluent\Actions\GetPaymentMethodUpdateUrl;
+use Vatly\Fluent\Actions\CreateBillingUpdateLink;
 use Vatly\Laravel\Models\Subscription;
 use Vatly\Laravel\Tests\BaseTestCase;
 
-class SubscriptionUpdatePaymentMethodTest extends BaseTestCase
+class SubscriptionCreateBillingUpdateLinkTest extends BaseTestCase
 {
     protected function tearDown(): void
     {
@@ -19,20 +19,20 @@ class SubscriptionUpdatePaymentMethodTest extends BaseTestCase
     }
 
     /** @test */
-    public function it_returns_the_payment_method_update_url(): void
+    public function it_returns_the_billing_update_link(): void
     {
-        $expectedUrl = 'https://checkout.vatly.com/update-payment/abc123';
+        $expectedUrl = 'https://checkout.vatly.com/billing-update/abc123';
 
-        $mockAction = Mockery::mock(GetPaymentMethodUpdateUrl::class);
+        $mockAction = Mockery::mock(CreateBillingUpdateLink::class);
         $mockAction->shouldReceive('execute')
             ->once()
             ->with('subscription_test123', [])
             ->andReturn(new Link($expectedUrl, 'text/html'));
 
-        app()->instance(GetPaymentMethodUpdateUrl::class, $mockAction);
+        app()->instance(CreateBillingUpdateLink::class, $mockAction);
 
         $subscription = new Subscription(['vatly_id' => 'subscription_test123']);
-        $url = $subscription->updatePaymentMethodUrl();
+        $url = $subscription->createBillingUpdateLink();
 
         $this->assertSame($expectedUrl, $url);
     }
@@ -42,17 +42,17 @@ class SubscriptionUpdatePaymentMethodTest extends BaseTestCase
     {
         $prefillData = ['billingAddress' => ['city' => 'Amsterdam']];
 
-        $mockAction = Mockery::mock(GetPaymentMethodUpdateUrl::class);
+        $mockAction = Mockery::mock(CreateBillingUpdateLink::class);
         $mockAction->shouldReceive('execute')
             ->once()
             ->with('subscription_test123', $prefillData)
-            ->andReturn(new Link('https://checkout.vatly.com/update', 'text/html'));
+            ->andReturn(new Link('https://checkout.vatly.com/billing-update', 'text/html'));
 
-        app()->instance(GetPaymentMethodUpdateUrl::class, $mockAction);
+        app()->instance(CreateBillingUpdateLink::class, $mockAction);
 
         $subscription = new Subscription(['vatly_id' => 'subscription_test123']);
-        $url = $subscription->updatePaymentMethodUrl($prefillData);
+        $url = $subscription->createBillingUpdateLink($prefillData);
 
-        $this->assertSame('https://checkout.vatly.com/update', $url);
+        $this->assertSame('https://checkout.vatly.com/billing-update', $url);
     }
 }


### PR DESCRIPTION
## Summary

Tracks the upstream renames in [vatly-fluent-php#17](https://github.com/Vatly/vatly-fluent-php/pull/17) → [vatly-api-php#14](https://github.com/Vatly/vatly-api-php/pull/14) → [vatlify#1377](https://github.com/sandervanhooft/vatlify/pull/1377).

### Rename

| Before | After |
|---|---|
| `Subscription::updatePaymentMethodUrl(): string` | `Subscription::createBillingUpdateLink(): string` |

Internally now resolves `Vatly\Fluent\Actions\CreateBillingUpdateLink` (was `GetPaymentMethodUpdateUrl`). Return value unchanged: still the URL string from the `Link`'s `href`.

### Why

- The endpoint the hosted page wraps edits **billing details** (address, VAT number, company name). The Mollie mandate refresh is an implementation-detail side effect of the UPDATE_DETAILS checkout, not the user-visible primary purpose.
- `createBillingUpdateLink` matches the verb (POST creates) + noun (signed-link resource) used at every layer of the stack now:
  - vatlify URL: `POST /subscriptions/{id}/billing-update-link`
  - OpenAPI operationId: `createSubscriptionBillingUpdateLink`
  - vatly-api-php: `Subscription::createBillingUpdateLink()`
  - vatly-fluent-php: `Actions\CreateBillingUpdateLink`
  - vatly-laravel (this PR): `Subscription::createBillingUpdateLink()`

### Pin bump

```diff
- "vatly/vatly-fluent-php": "0.4.0-alpha.2"
+ "vatly/vatly-fluent-php": "0.4.0-alpha.3"
```

## Test plan

- [x] `composer test` — 49/49 pass
- [ ] **CI will fail** until fluent-php `0.4.0-alpha.3` is published to Packagist. Merge order: api-php#14 → release → fluent-php#17 → release → re-run CI here → merge

## Out of scope

- The vatly-docs api-reference + `public/openapi.yaml` updates ship separately. The `content/3.packages/2.laravel/*` content gets auto-synced from this repo's `docs/` via the `sync-sdk-docs` workflow once this merges.
