### PR TITLE
docs: polish README for Cashier-style adoption

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,17 +6,21 @@
 
 > **Alpha release -- under active development. Expect breaking changes.**
 
-Laravel integration for [Vatly](https://vatly.com) billing, inspired by Laravel Cashier. Provides Eloquent models, a `Billable` trait, Eloquent-aware checkout/subscription builders, Eloquent repositories, a webhook controller, and an event-bus bridge that forwards Vatly events onto Laravel's `Event` facade so you can register listeners the usual way.
+A Cashier-style integration for [Vatly](https://vatly.com) in your Laravel application. Drop a `Billable` trait on your User model and you get subscriptions, checkouts, customer management, hosted billing update links, and a fully wired webhook endpoint — built around Eloquent and Laravel's IoC, events, and routing.
 
-Built on top of [vatly/vatly-fluent-php](https://github.com/Vatly/vatly-fluent-php) — the framework-agnostic core that this package adapts to Laravel.
+If you've used Laravel Cashier for Stripe, this will feel familiar. Vatly handles Merchant of Record billing for EU SaaS, so you get a similar developer experience without managing VAT, invoicing, or payment compliance yourself.
 
-## Installation
+## Documentation
 
-```bash
-composer require vatly/vatly-laravel:v0.3.0-alpha.1
-```
+Full docs at [docs.vatly.com](https://docs.vatly.com). In this repo:
 
-Pin to an exact version. This is an alpha release and the API will change.
+- [Getting started](docs/README.md)
+- [Configuration](docs/configuration.md)
+- [Customers](docs/Customers.md)
+- [Checkouts](docs/Checkouts.md)
+- [Subscriptions](docs/Subscriptions.md)
+- [Orders](docs/Orders.md)
+- [Webhooks](docs/Webhooks.md)
 
 ## Requirements
 
@@ -24,42 +28,54 @@ Pin to an exact version. This is an alpha release and the API will change.
 - Laravel 11 or 12
 - A Vatly API key ([vatly.com](https://vatly.com))
 
+## Installation
+
+```bash
+composer require vatly/vatly-laravel:v0.3.0-alpha.1
+```
+
+Pin to an exact version during alpha — the API will change.
+
 ## Setup
 
-1. Publish the config:
+1. **Publish the config:**
 
-```bash
-php artisan vendor:publish --tag=vatly-config
-```
+   ```bash
+   php artisan vendor:publish --tag=vatly-config
+   ```
 
-2. Add your API key to `.env`:
+2. **Add credentials to `.env`:**
 
-```
-VATLY_KEY=test_xxxxxxxxxxxx
-VATLY_WEBHOOK_SECRET=your-webhook-secret
-```
+   ```env
+   VATLY_KEY=test_xxxxxxxxxxxx
+   VATLY_WEBHOOK_SECRET=your-webhook-secret
+   VATLY_REDIRECT_URL_SUCCESS=https://your-app.test/checkout/success
+   VATLY_REDIRECT_URL_CANCELED=https://your-app.test/checkout/canceled
+   ```
 
-See [docs/configuration.md](docs/configuration.md) for the full list of config options.
+   See [docs/configuration.md](docs/configuration.md) for the full list. Testmode is inferred from the key prefix (`test_` vs `live_`) — no extra config needed.
 
-3. Publish and run migrations:
+3. **Publish and run migrations:**
 
-```bash
-php artisan vendor:publish --tag=vatly-migrations
-php artisan vendor:publish --tag=vatly-billable-migrations
-php artisan migrate
-```
+   ```bash
+   php artisan vendor:publish --tag=vatly-migrations
+   php artisan vendor:publish --tag=vatly-billable-migrations
+   php artisan migrate
+   ```
 
-4. Add the `Billable` trait to your User model:
+   This adds a `vatly_id` column to your users table plus `vatly_subscriptions`, `vatly_orders`, and `vatly_webhook_calls` tables.
 
-```php
-use Vatly\Laravel\Contracts\BillableInterface;
-use Vatly\Laravel\Billable;
+4. **Add the `Billable` trait to your User model:**
 
-class User extends Authenticatable implements BillableInterface
-{
-    use Billable;
-}
-```
+   ```php
+   use Vatly\Fluent\Contracts\BillableInterface;
+   use Vatly\Laravel\Billable;
+
+   class User extends Authenticatable implements BillableInterface
+   {
+       use Billable;
+   }
+   ```
 
 ## Usage
 
@@ -72,18 +88,36 @@ $checkout = $user->newCheckout()
         redirectUrlCanceled: 'https://example.com/canceled',
     );
 
-// Swap subscription plan
+// Check subscription state
+$user->subscribed('default');                // bool
+$user->subscription('default')->onGracePeriod();
+$user->subscription('default')->cancelled();
+
+// Swap plan
 $user->subscription('default')->swap('plan_premium');
 
-// Cancel subscription
-$user->subscription('default')->cancel();
+// Cancel
+$user->subscription('default')->cancel();    // at period end
 ```
+
+See [docs/Subscriptions.md](docs/Subscriptions.md) and [docs/Checkouts.md](docs/Checkouts.md) for the full surface.
 
 ## Webhooks
 
-The package registers a webhook endpoint at `/webhooks/vatly` automatically. Configure your webhook secret in the Vatly dashboard.
+The package registers `POST /webhooks/vatly` automatically. Set this URL and your `VATLY_WEBHOOK_SECRET` in the Vatly dashboard, and subscriptions/orders sync to your database automatically.
 
-Events dispatched (from [`vatly/vatly-fluent-php`](https://github.com/Vatly/vatly-fluent-php)):
+Vatly events are dispatched on Laravel's event bus — register listeners the usual way:
+
+```php
+use Vatly\Fluent\Events\OrderPaid;
+
+Event::listen(OrderPaid::class, function (OrderPaid $event) {
+    // send receipt, etc.
+});
+```
+
+Events available:
+
 - `Vatly\Fluent\Events\WebhookReceived`
 - `Vatly\Fluent\Events\OrderPaid`
 - `Vatly\Fluent\Events\SubscriptionStarted`
@@ -92,11 +126,17 @@ Events dispatched (from [`vatly/vatly-fluent-php`](https://github.com/Vatly/vatl
 - `Vatly\Fluent\Events\LocalSubscriptionCreated`
 - `Vatly\Fluent\Events\UnsupportedWebhookReceived`
 
+See [docs/Webhooks.md](docs/Webhooks.md) for signature verification, retries, and customising reactions.
+
 ## Testing
 
 ```bash
 composer test
 ```
+
+## Under the hood
+
+This package is the Laravel driver for [`vatly/vatly-fluent-php`](https://github.com/Vatly/vatly-fluent-php), which holds the framework-agnostic webhook pipeline and contracts shared across drivers. You don't need to interact with fluent directly — it's an implementation detail. If you're building an integration for a different framework, see fluent's [Driver Author Guide](https://github.com/Vatly/vatly-fluent-php/blob/main/CONTRIBUTING.md).
 
 ## License
 


### PR DESCRIPTION
## Summary
- Leads with **"Cashier-style integration for Vatly"** so devs searching for a Vatly equivalent of Cashier find it.
- Surfaces the **Merchant of Record** positioning explicitly (Vatly's differentiator for EU SaaS).
- Fixes a **namespace bug**: `Vatly\Laravel\Contracts\BillableInterface` → `Vatly\Fluent\Contracts\BillableInterface` (the actual class lives in fluent).
- Expands setup, usage, and webhooks sections; links the `docs/` files that already power docs.vatly.com.
- Demotes the `vatly-fluent-php` mention to an "Under the hood" footer so fluent reads as an implementation detail, not a co-equal product.

## Why
Laravel devs landing here from a Cashier-alternative search should get a Cashier-style README, not an architecture explanation. Fluent's role is real but it's plumbing, not product.

## Test plan
- [x] `composer test` → 49/49 pass (README-only change)
- [x] All linked `docs/` files exist
- [x] `docs.vatly.com` will rebuild via existing sync workflow
