### PR TITLE
docs: scope messaging to Laravel only

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ composer test
 
 ## Under the hood
 
-This package is the Laravel driver for [`vatly/vatly-fluent-php`](https://github.com/Vatly/vatly-fluent-php), which holds the framework-agnostic webhook pipeline and contracts shared across drivers. You don't need to interact with fluent directly — it's an implementation detail. If you're building an integration for a different framework, see fluent's [Driver Author Guide](https://github.com/Vatly/vatly-fluent-php/blob/main/CONTRIBUTING.md).
+This package builds on [`vatly/vatly-fluent-php`](https://github.com/Vatly/vatly-fluent-php), which holds the webhook pipeline, contracts, events, DTOs, and the `Vatly\Fluent\Billable` orchestrator. You don't need to interact with fluent directly — it's an implementation detail of vatly-laravel.
 
 ## License
 


### PR DESCRIPTION
## Summary

Removed the "Driver Author Guide" pointer from README's "Under the hood" section. Mirrors the corresponding [vatly-fluent-php cleanup](https://github.com/Vatly/vatly-fluent-php/pulls).

## Changed

The "If you're building an integration for a different framework, see fluent's Driver Author Guide" sentence is gone. The architectural relationship to vatly-fluent-php remains documented (it's an honest implementation detail), but we no longer suggest building drivers for other frameworks is part of the product story.

## Why

Focusing the project on Laravel. Other-framework references were aspirational rather than supported.

## Test plan
- [x] composer test → 27/27 pass
- [x] No 'Symfony' / 'WordPress' references in README, src/, or docs/
