### PR TITLE
chore: support Laravel 13 + PHP 8.3-8.5; drop Laravel 11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,11 +13,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.2, 8.3, 8.4]
-        laravel: [11.*, 12.*]
-        exclude:
-          - php: 8.2
-            laravel: 12.*
+        php: [8.3, 8.4, 8.5]
+        laravel: [12.*, 13.*]
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Full docs at [docs.vatly.com](https://docs.vatly.com). In this repo:
 
 ## Requirements
 
-- PHP 8.2+
-- Laravel 11 or 12
+- PHP 8.3+
+- Laravel 12 or 13
 - A Vatly API key ([vatly.com](https://vatly.com))
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ composer test
 
 ## Under the hood
 
-This package is the Laravel driver for [`vatly/vatly-fluent-php`](https://github.com/Vatly/vatly-fluent-php), which holds the framework-agnostic webhook pipeline and contracts shared across drivers. You don't need to interact with fluent directly — it's an implementation detail. If you're building an integration for a different framework, see fluent's [Driver Author Guide](https://github.com/Vatly/vatly-fluent-php/blob/main/CONTRIBUTING.md).
+This package builds on [`vatly/vatly-fluent-php`](https://github.com/Vatly/vatly-fluent-php), which holds the webhook pipeline, contracts, events, DTOs, and the `Vatly\Fluent\Billable` orchestrator. You don't need to interact with fluent directly — it's an implementation detail of vatly-laravel.
 
 ## License
 

--- a/composer.json
+++ b/composer.json
@@ -15,19 +15,19 @@
         }
     ],
     "require": {
-        "php": "^8.2",
-        "illuminate/contracts": "^11.0|^12.0",
-        "illuminate/database": "^11.0|^12.0",
-        "illuminate/http": "^11.0|^12.0",
-        "illuminate/routing": "^11.0|^12.0",
-        "illuminate/support": "^11.0|^12.0",
+        "php": "^8.3",
+        "illuminate/contracts": "^12.0|^13.0",
+        "illuminate/database": "^12.0|^13.0",
+        "illuminate/http": "^12.0|^13.0",
+        "illuminate/routing": "^12.0|^13.0",
+        "illuminate/support": "^12.0|^13.0",
         "vatly/vatly-fluent-php": "0.5.0-alpha.1"
     },
     "require-dev": {
         "larastan/larastan": "^3.9",
         "mockery/mockery": "^1.6",
-        "orchestra/testbench": "^9.0|^10.0",
-        "phpunit/phpunit": "^11.0"
+        "orchestra/testbench": "^10.0|^11.0",
+        "phpunit/phpunit": "^11.0|^12.0"
     },
     "autoload": {
         "psr-4": {

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,8 +4,8 @@ Vatly Laravel provides a Cashier-like integration for [Vatly](https://vatly.com)
 
 ## Requirements
 
-- PHP 8.2+
-- Laravel 11 or 12
+- PHP 8.3+
+- Laravel 12 or 13
 - A Vatly API key
 
 ## Installation

--- a/tests/Http/Controllers/VatlyInboundWebhookControllerTest.php
+++ b/tests/Http/Controllers/VatlyInboundWebhookControllerTest.php
@@ -23,8 +23,7 @@ class VatlyInboundWebhookControllerTest extends BaseTestCase
         $this->app->forgetInstance(WebhookProcessor::class);
     }
 
-    /** @test */
-    public function it_returns_201_for_a_valid_signed_webhook(): void
+    public function test_it_returns_201_for_a_valid_signed_webhook(): void
     {
         User::factory()->create(['vatly_id' => 'customer_foo']);
 
@@ -43,8 +42,7 @@ class VatlyInboundWebhookControllerTest extends BaseTestCase
         $this->assertDatabaseCount('vatly_webhook_calls', 1);
     }
 
-    /** @test */
-    public function it_handles_unknown_webhook_events(): void
+    public function test_it_handles_unknown_webhook_events(): void
     {
         $payload = $this->makePayload('unknown.event.type', 'res_123', 'unknown', ['foo' => 'bar']);
 
@@ -54,8 +52,7 @@ class VatlyInboundWebhookControllerTest extends BaseTestCase
         $this->assertDatabaseCount('vatly_webhook_calls', 1);
     }
 
-    /** @test */
-    public function it_returns_403_for_an_invalid_signature(): void
+    public function test_it_returns_403_for_an_invalid_signature(): void
     {
         $payload = $this->makePayload('subscription.started', 'sub_123', 'subscription');
 
@@ -70,8 +67,7 @@ class VatlyInboundWebhookControllerTest extends BaseTestCase
         $this->assertDatabaseCount('vatly_webhook_calls', 0);
     }
 
-    /** @test */
-    public function it_returns_403_for_a_missing_signature(): void
+    public function test_it_returns_403_for_a_missing_signature(): void
     {
         $payload = $this->makePayload('subscription.started', 'sub_123', 'subscription');
 
@@ -85,8 +81,7 @@ class VatlyInboundWebhookControllerTest extends BaseTestCase
         $response->assertStatus(403);
     }
 
-    /** @test */
-    public function it_creates_a_subscription_from_webhook(): void
+    public function test_it_creates_a_subscription_from_webhook(): void
     {
         $user = User::factory()->create(['vatly_id' => 'customer_abc']);
 
@@ -110,8 +105,7 @@ class VatlyInboundWebhookControllerTest extends BaseTestCase
         ]);
     }
 
-    /** @test */
-    public function it_creates_an_order_from_webhook(): void
+    public function test_it_creates_an_order_from_webhook(): void
     {
         $user = User::factory()->create(['vatly_id' => 'customer_abc']);
 
@@ -137,8 +131,7 @@ class VatlyInboundWebhookControllerTest extends BaseTestCase
         ]);
     }
 
-    /** @test */
-    public function it_cancels_a_subscription_immediately_from_webhook(): void
+    public function test_it_cancels_a_subscription_immediately_from_webhook(): void
     {
         $user = User::factory()->create(['vatly_id' => 'customer_abc']);
 

--- a/tests/Models/OrderTest.php
+++ b/tests/Models/OrderTest.php
@@ -14,16 +14,14 @@ class OrderTest extends BaseTestCase
 {
     use RefreshDatabase;
 
-    /** @test */
-    public function it_implements_order_interface(): void
+    public function test_it_implements_order_interface(): void
     {
         $order = new Order();
 
         $this->assertInstanceOf(OrderInterface::class, $order);
     }
 
-    /** @test */
-    public function it_can_be_created_with_attributes(): void
+    public function test_it_can_be_created_with_attributes(): void
     {
         $user = User::create([
             'name' => 'Test User',
@@ -51,8 +49,7 @@ class OrderTest extends BaseTestCase
         $this->assertTrue($order->isPaid());
     }
 
-    /** @test */
-    public function it_has_a_morph_to_owner_relationship(): void
+    public function test_it_has_a_morph_to_owner_relationship(): void
     {
         $user = User::create([
             'name' => 'Test User',
@@ -73,8 +70,7 @@ class OrderTest extends BaseTestCase
         $this->assertSame($user->id, $order->owner->id);
     }
 
-    /** @test */
-    public function user_can_access_orders_via_relationship(): void
+    public function test_user_can_access_orders_via_relationship(): void
     {
         $user = User::create([
             'name' => 'Test User',
@@ -103,8 +99,7 @@ class OrderTest extends BaseTestCase
         $this->assertCount(2, $user->orders);
     }
 
-    /** @test */
-    public function is_paid_returns_false_for_non_paid_orders(): void
+    public function test_is_paid_returns_false_for_non_paid_orders(): void
     {
         $order = new Order(['status' => 'pending']);
 

--- a/tests/Models/SubscriptionTest.php
+++ b/tests/Models/SubscriptionTest.php
@@ -13,8 +13,7 @@ class SubscriptionTest extends BaseTestCase
 {
     use RefreshDatabase;
 
-    /** @test */
-    public function it_implements_subscription_interface_getters()
+    public function test_it_implements_subscription_interface_getters()
     {
         $user = User::factory()->create([
             'vatly_id' => 'customer_456',
@@ -38,8 +37,7 @@ class SubscriptionTest extends BaseTestCase
         $this->assertNull($subscription->getEndsAt());
     }
 
-    /** @test */
-    public function it_identifies_active_subscriptions()
+    public function test_it_identifies_active_subscriptions()
     {
         $user = User::factory()->create([
             'vatly_id' => 'customer_789',
@@ -61,8 +59,7 @@ class SubscriptionTest extends BaseTestCase
         $this->assertFalse($subscription->isOnGracePeriod());
     }
 
-    /** @test */
-    public function it_identifies_canceled_subscriptions()
+    public function test_it_identifies_canceled_subscriptions()
     {
         $user = User::factory()->create([
             'vatly_id' => 'customer_canceled',
@@ -84,8 +81,7 @@ class SubscriptionTest extends BaseTestCase
         $this->assertFalse($subscription->isOnGracePeriod());
     }
 
-    /** @test */
-    public function it_identifies_subscriptions_on_grace_period()
+    public function test_it_identifies_subscriptions_on_grace_period()
     {
         $user = User::factory()->create([
             'vatly_id' => 'customer_grace',


### PR DESCRIPTION
## Summary

Aligns the supported stack with what's currently active upstream as of May 2026.

### Laravel
- **Laravel 11** dropped — security support EOL'd **March 12, 2026**.
- **Laravel 12** kept — bug fixes through Aug 2026, security through Feb 2027.
- **Laravel 13** added — released March 17, 2026. Requires PHP 8.3+.

### PHP
Floor raised **8.2 → 8.3** (required by Laravel 13). PHP 8.3, 8.4, 8.5 are all in active support.

### Dev tooling
- \`orchestra/testbench\`: \`^9.0|^10.0\` → \`^10.0|^11.0\` (testbench 11 = Laravel 13).
- \`phpunit/phpunit\`: \`^11.0\` → \`^11.0|^12.0\` (testbench 11 ships with PHPUnit 12).
- Model + controller tests using the legacy \`/** @test */\` annotation (removed in PHPUnit 12) converted to the \`test_*\` method-name convention so they discover cleanly under both PHPUnit 11 and 12.

### CI matrix

Before: PHP 8.2-8.4 × Laravel 11-12 (with PHP 8.2 + Laravel 12 excluded).
After: PHP 8.3-8.5 × Laravel 12-13. No exclusions — every combination is valid.

### Docs
README + docs/README.md updated to \`PHP 8.3+\` and \`Laravel 12 or 13\`.

## Test plan
- [x] \`composer update\` resolves cleanly with new constraints
- [x] \`composer test\` → 27/27 pass on PHP 8.5 + Laravel 13 + PHPUnit 12
- [ ] CI green across the full PHP 8.3-8.5 × Laravel 12-13 matrix
