### PR TITLE
Dev XP log #3: surface tax breakdown, idempotent migration, rename webhook route

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,12 +131,14 @@ Event::listen(OrderPaid::class, function (OrderPaid $event) {
 Events available:
 
 - `Vatly\Fluent\Events\WebhookReceived`
-- `Vatly\Fluent\Events\OrderPaid`
+- `Vatly\Fluent\Events\OrderPaid` — carries `total`, `subtotal`, `taxSummary` (full per-rate breakdown), `currency`, `invoiceNumber`, `paymentMethod`. Materialize local invoices without an extra API call.
 - `Vatly\Fluent\Events\SubscriptionStarted`
 - `Vatly\Fluent\Events\SubscriptionCanceledImmediately`
 - `Vatly\Fluent\Events\SubscriptionCanceledWithGracePeriod`
 - `Vatly\Fluent\Events\LocalSubscriptionCreated`
 - `Vatly\Fluent\Events\UnsupportedWebhookReceived`
+
+The webhook route is named `vatly.webhook` — reach it with `route('vatly.webhook')`.
 
 See [docs/Webhooks.md](docs/Webhooks.md) for signature verification, retries, and customising reactions.
 
@@ -144,6 +146,19 @@ See [docs/Webhooks.md](docs/Webhooks.md) for signature verification, retries, an
 
 ```bash
 composer test
+```
+
+When testing code that calls the `Billable` trait shortcuts, your test models must implement `BillableInterface` (applying the trait does this for you). The contract is enforced at runtime — there's no "loose" mode.
+
+For the `order.paid` webhook flow, the package fetches the full Order from the Vatly API to populate the tax breakdown. In integration tests, swap the `GetOrder` action with a Mockery mock:
+
+```php
+use Mockery;
+use Vatly\Fluent\Actions\GetOrder;
+
+$action = Mockery::mock(GetOrder::class);
+$action->shouldReceive('execute')->andReturn($yourFakeApiOrder);
+$this->app->instance(GetOrder::class, $action);
 ```
 
 ## Under the hood

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "illuminate/http": "^12.0|^13.0",
         "illuminate/routing": "^12.0|^13.0",
         "illuminate/support": "^12.0|^13.0",
-        "vatly/vatly-fluent-php": "0.5.0-alpha.1"
+        "vatly/vatly-fluent-php": "0.5.0-alpha.2"
     },
     "require-dev": {
         "larastan/larastan": "^3.9",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "illuminate/http": "^12.0|^13.0",
         "illuminate/routing": "^12.0|^13.0",
         "illuminate/support": "^12.0|^13.0",
-        "vatly/vatly-fluent-php": "0.5.0-alpha.2"
+        "vatly/vatly-fluent-php": "0.6.0-alpha.1"
     },
     "require-dev": {
         "larastan/larastan": "^3.9",

--- a/database/migrations/create_vatly_billable_columns.php.stub
+++ b/database/migrations/create_vatly_billable_columns.php.stub
@@ -12,8 +12,13 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('users', function (Blueprint $table) {
-            $table->string('vatly_id')->nullable()->index();
-            $table->timestamp('trial_ends_at')->nullable();
+            if (! Schema::hasColumn('users', 'vatly_id')) {
+                $table->string('vatly_id')->nullable()->index();
+            }
+
+            if (! Schema::hasColumn('users', 'trial_ends_at')) {
+                $table->timestamp('trial_ends_at')->nullable();
+            }
         });
     }
 
@@ -22,9 +27,17 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::dropColumns('users', [
-            'vatly_id',
-            'trial_ends_at',
-        ]);
+        Schema::table('users', function (Blueprint $table) {
+            if (Schema::hasColumn('users', 'vatly_id')) {
+                if (Schema::hasIndex('users', 'users_vatly_id_index')) {
+                    $table->dropIndex('users_vatly_id_index');
+                }
+                $table->dropColumn('vatly_id');
+            }
+
+            if (Schema::hasColumn('users', 'trial_ends_at')) {
+                $table->dropColumn('trial_ends_at');
+            }
+        });
     }
 };

--- a/database/migrations/create_vatly_orders_table.php.stub
+++ b/database/migrations/create_vatly_orders_table.php.stub
@@ -14,6 +14,8 @@ return new class extends Migration
             $table->string('vatly_id')->unique();
             $table->string('status');
             $table->integer('total');
+            $table->integer('subtotal')->nullable();
+            $table->json('tax_summary')->nullable();
             $table->string('currency', 3);
             $table->string('invoice_number')->nullable();
             $table->string('payment_method')->nullable();

--- a/docs/Subscriptions.md
+++ b/docs/Subscriptions.md
@@ -17,7 +17,7 @@ $subscription = $user->subscription('premium');
 $subscriptions = $user->subscriptions; // Collection<Subscription>
 ```
 
-`$user->subscription('default')` returns a `Vatly\Fluent\SubscriptionHandle` — a lightweight wrapper around the underlying Eloquent model that exposes API-driven operations (`swap`, `cancel`, `sync`, `createBillingUpdateLink`). Reach the Eloquent model via `$subscription->model()` if you need it directly.
+`$user->subscription('default')` returns a `Vatly\Fluent\SubscriptionHandle` — a lightweight wrapper around the underlying Eloquent model that exposes API-driven operations (`swap`, `cancel`, `sync`, `updateBilling`). Reach the Eloquent model via `$subscription->model()` if you need it directly.
 
 ## Subscription state
 
@@ -55,7 +55,7 @@ The actual cancellation is processed via webhooks. Depending on the Vatly config
 // Create a signed URL where the customer can update their billing details
 // (address, VAT number, company name). Going through the hosted flow also
 // refreshes the Mollie mandate as a side effect.
-$url = $user->subscription()->createBillingUpdateLink();
+$url = $user->subscription()->updateBilling();
 
 return redirect($url);
 ```

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,4 +6,4 @@ use Illuminate\Support\Facades\Route;
 use Vatly\Laravel\Http\Controllers\VatlyInboundWebhookController;
 
 Route::post('webhooks/vatly', VatlyInboundWebhookController::class)
-    ->name('webhook');
+    ->name('vatly.webhook');

--- a/src/Models/Order.php
+++ b/src/Models/Order.php
@@ -15,6 +15,8 @@ use Vatly\Fluent\Contracts\OrderInterface;
  * @property int $owner_id
  * @property string $status
  * @property int $total
+ * @property int|null $subtotal
+ * @property array<int, array{rate: array{name: string, percentage: float, taxablePercentage: float}, amount: int, currency: string}>|null $tax_summary
  * @property string $currency
  * @property string|null $invoice_number
  * @property string|null $payment_method
@@ -27,6 +29,13 @@ class Order extends Model implements OrderInterface
     protected $table = 'vatly_orders';
 
     protected $guarded = [];
+
+    /**
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'tax_summary' => 'array',
+    ];
 
     /**
      * @return MorphTo<Model, Order>

--- a/src/Models/Subscription.php
+++ b/src/Models/Subscription.php
@@ -14,7 +14,7 @@ use Vatly\Fluent\Contracts\SubscriptionInterface;
 /**
  * The local representation of a Vatly subscription.
  *
- * State-only — operations (swap, cancel, sync, createBillingUpdateLink)
+ * State-only — operations (swap, cancel, sync, updateBilling)
  * live on Vatly\Fluent\SubscriptionHandle and are reached via
  * $user->subscription('default').
  *

--- a/src/Repositories/EloquentOrderRepository.php
+++ b/src/Repositories/EloquentOrderRepository.php
@@ -48,6 +48,8 @@ class EloquentOrderRepository implements OrderRepositoryInterface
             'owner_id' => $owner->getKey(),
             'status' => $data->status,
             'total' => $data->total,
+            'subtotal' => $data->subtotal,
+            'tax_summary' => $data->taxSummary?->toArray(),
             'currency' => $data->currency,
             'invoice_number' => $data->invoiceNumber,
             'payment_method' => $data->paymentMethod,
@@ -62,6 +64,12 @@ class EloquentOrderRepository implements OrderRepositoryInterface
             }
             if ($data->total !== null) {
                 $order->total = $data->total;
+            }
+            if ($data->subtotal !== null) {
+                $order->subtotal = $data->subtotal;
+            }
+            if ($data->taxSummary !== null) {
+                $order->tax_summary = $data->taxSummary->toArray();
             }
             if ($data->currency !== null) {
                 $order->currency = $data->currency;

--- a/src/VatlyServiceProvider.php
+++ b/src/VatlyServiceProvider.php
@@ -9,7 +9,7 @@ use Vatly\API\VatlyApiClient;
 use Vatly\Fluent\Actions\CancelSubscription;
 use Vatly\Fluent\Actions\CreateCheckout;
 use Vatly\Fluent\Actions\CreateCustomer;
-use Vatly\Fluent\Actions\CreateSubscriptionBillingUpdateLink;
+use Vatly\Fluent\Actions\UpdateSubscriptionBilling;
 use Vatly\Fluent\Actions\GetCheckout;
 use Vatly\Fluent\Actions\GetCustomer;
 use Vatly\Fluent\Actions\GetSubscription;
@@ -81,7 +81,7 @@ class VatlyServiceProvider extends ServiceProvider
             CreateCheckout::class,
             GetCheckout::class,
             GetSubscription::class,
-            CreateSubscriptionBillingUpdateLink::class,
+            UpdateSubscriptionBilling::class,
             CancelSubscription::class,
             SwapSubscriptionPlan::class,
         ];
@@ -120,7 +120,7 @@ class VatlyServiceProvider extends ServiceProvider
                 getSubscriptionAction: $this->app->make(GetSubscription::class),
                 swapSubscriptionPlanAction: $this->app->make(SwapSubscriptionPlan::class),
                 cancelSubscriptionAction: $this->app->make(CancelSubscription::class),
-                createBillingUpdateLinkAction: $this->app->make(CreateSubscriptionBillingUpdateLink::class),
+                updateBillingAction: $this->app->make(UpdateSubscriptionBilling::class),
             );
         });
     }

--- a/src/VatlyServiceProvider.php
+++ b/src/VatlyServiceProvider.php
@@ -12,6 +12,7 @@ use Vatly\Fluent\Actions\CreateCustomer;
 use Vatly\Fluent\Actions\UpdateSubscriptionBilling;
 use Vatly\Fluent\Actions\GetCheckout;
 use Vatly\Fluent\Actions\GetCustomer;
+use Vatly\Fluent\Actions\GetOrder;
 use Vatly\Fluent\Actions\GetSubscription;
 use Vatly\Fluent\Actions\SwapSubscriptionPlan;
 use Vatly\Fluent\BillableFactory;
@@ -78,6 +79,7 @@ class VatlyServiceProvider extends ServiceProvider
         $actions = [
             CreateCustomer::class,
             GetCustomer::class,
+            GetOrder::class,
             CreateCheckout::class,
             GetCheckout::class,
             GetSubscription::class,
@@ -134,6 +136,7 @@ class VatlyServiceProvider extends ServiceProvider
                 orders: $this->app->make(OrderRepositoryInterface::class),
                 webhookCalls: $this->app->make(WebhookCallRepositoryInterface::class),
                 dispatcher: $this->app->make(EventDispatcherInterface::class),
+                getOrder: $this->app->make(GetOrder::class),
             );
         });
     }

--- a/tests/Feature/Migrations/BillableColumnsMigrationTest.php
+++ b/tests/Feature/Migrations/BillableColumnsMigrationTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Laravel\Tests\Feature\Migrations;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Vatly\Laravel\Tests\BaseTestCase;
+
+class BillableColumnsMigrationTest extends BaseTestCase
+{
+    private const STUB_PATH = __DIR__ . '/../../../database/migrations/create_vatly_billable_columns.php.stub';
+
+    protected function defineDatabaseMigrations(): void
+    {
+        // Skip the fixture migrations so we own the users-table shape here.
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::dropIfExists('users');
+        Schema::create('users', function (Blueprint $table) {
+            $table->id();
+            $table->string('email')->unique();
+        });
+    }
+
+    public function test_it_adds_columns_when_missing(): void
+    {
+        $this->migrateUp();
+
+        $this->assertTrue(Schema::hasColumn('users', 'vatly_id'));
+        $this->assertTrue(Schema::hasColumn('users', 'trial_ends_at'));
+    }
+
+    public function test_running_up_twice_does_not_throw(): void
+    {
+        $this->migrateUp();
+        $this->migrateUp();
+
+        $this->assertTrue(Schema::hasColumn('users', 'vatly_id'));
+        $this->assertTrue(Schema::hasColumn('users', 'trial_ends_at'));
+    }
+
+    public function test_up_is_a_noop_when_columns_already_exist(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('vatly_id')->nullable();
+            $table->timestamp('trial_ends_at')->nullable();
+        });
+
+        $this->migrateUp();
+
+        $this->assertTrue(Schema::hasColumn('users', 'vatly_id'));
+        $this->assertTrue(Schema::hasColumn('users', 'trial_ends_at'));
+    }
+
+    public function test_down_only_drops_columns_that_exist(): void
+    {
+        $this->migrateUp();
+        $this->migrateDown();
+
+        $this->assertFalse(Schema::hasColumn('users', 'vatly_id'));
+        $this->assertFalse(Schema::hasColumn('users', 'trial_ends_at'));
+
+        $this->migrateDown();
+        $this->assertFalse(Schema::hasColumn('users', 'vatly_id'));
+    }
+
+    private function migrateUp(): void
+    {
+        (require self::STUB_PATH)->up();
+    }
+
+    private function migrateDown(): void
+    {
+        (require self::STUB_PATH)->down();
+    }
+}

--- a/tests/Fixtures/migrations/2024_01_01_000002_create_vatly_tables.php
+++ b/tests/Fixtures/migrations/2024_01_01_000002_create_vatly_tables.php
@@ -27,6 +27,8 @@ return new class extends Migration
             $table->string('vatly_id')->unique();
             $table->string('status');
             $table->integer('total');
+            $table->integer('subtotal')->nullable();
+            $table->json('tax_summary')->nullable();
             $table->string('currency');
             $table->string('invoice_number')->nullable();
             $table->string('payment_method')->nullable();

--- a/tests/Http/Controllers/VatlyInboundWebhookControllerTest.php
+++ b/tests/Http/Controllers/VatlyInboundWebhookControllerTest.php
@@ -6,6 +6,12 @@ namespace Vatly\Laravel\Tests\Http\Controllers;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Mockery;
+use Vatly\API\Resources\Order as ApiOrder;
+use Vatly\API\Types\Money;
+use Vatly\API\Types\TaxSummaryCollection;
+use Vatly\API\VatlyApiClient;
+use Vatly\Fluent\Actions\GetOrder;
 use Vatly\Fluent\Webhooks\WebhookProcessor;
 use Vatly\Laravel\Tests\BaseTestCase;
 
@@ -109,7 +115,20 @@ class VatlyInboundWebhookControllerTest extends BaseTestCase
     {
         $user = User::factory()->create(['vatly_id' => 'customer_abc']);
 
-        $payload = $this->makePayload('order.paid', 'ord_123', 'order', [
+        $this->fakeGetOrder($this->buildApiOrder([
+            'id' => 'order_abc123',
+            'customerId' => 'customer_abc',
+            'totalValue' => '99.00',
+            'subtotalValue' => '81.82',
+            'currency' => 'EUR',
+            'invoiceNumber' => 'INV-001',
+            'paymentMethod' => 'card',
+            'taxRates' => [
+                ['name' => 'VAT', 'percentage' => 21.0, 'taxablePercentage' => 100.0, 'amount' => '17.18'],
+            ],
+        ]));
+
+        $payload = $this->makePayload('order.paid', 'order_abc123', 'order', [
             'data' => [
                 'customerId' => 'customer_abc',
                 'total' => 9900,
@@ -123,12 +142,94 @@ class VatlyInboundWebhookControllerTest extends BaseTestCase
 
         $response->assertStatus(201);
         $this->assertDatabaseHas('vatly_orders', [
-            'vatly_id' => 'ord_123',
+            'vatly_id' => 'order_abc123',
             'status' => 'paid',
             'total' => 9900,
             'currency' => 'EUR',
             'owner_id' => $user->id,
         ]);
+    }
+
+    public function test_it_persists_tax_breakdown_when_creating_an_order_from_webhook(): void
+    {
+        $user = User::factory()->create(['vatly_id' => 'customer_abc']);
+
+        $this->fakeGetOrder($this->buildApiOrder([
+            'id' => 'order_tax_1',
+            'customerId' => 'customer_abc',
+            'totalValue' => '49.99',
+            'subtotalValue' => '41.31',
+            'currency' => 'USD',
+            'invoiceNumber' => null,
+            'paymentMethod' => null,
+            'taxRates' => [
+                ['name' => 'Sales Tax', 'percentage' => 21.0, 'taxablePercentage' => 100.0, 'amount' => '8.68'],
+            ],
+        ]));
+
+        $payload = $this->makePayload('order.paid', 'order_tax_1', 'order', [
+            'data' => [
+                'customerId' => 'customer_abc',
+                'total' => 4999,
+                'currency' => 'USD',
+            ],
+        ]);
+
+        $response = $this->postWebhook($payload);
+
+        $response->assertStatus(201);
+
+        $order = \Vatly\Laravel\Models\Order::where('vatly_id', 'order_tax_1')->firstOrFail();
+        $this->assertSame(4131, $order->subtotal);
+        $this->assertSame('Sales Tax', $order->tax_summary[0]['rate']['name']);
+        $this->assertSame(868, $order->tax_summary[0]['amount']);
+        $this->assertSame('USD', $order->tax_summary[0]['currency']);
+        $this->assertSame($user->id, $order->owner_id);
+    }
+
+    private function fakeGetOrder(ApiOrder $order): void
+    {
+        $action = Mockery::mock(GetOrder::class);
+        $action->shouldReceive('execute')->andReturn($order);
+        $this->app->instance(GetOrder::class, $action);
+        $this->app->forgetInstance(WebhookProcessor::class);
+    }
+
+    /**
+     * @param array{
+     *   id: string,
+     *   customerId: string,
+     *   totalValue: string,
+     *   subtotalValue: string,
+     *   currency: string,
+     *   invoiceNumber: ?string,
+     *   paymentMethod: ?string,
+     *   taxRates: array<int, array{name: string, percentage: float, taxablePercentage: float, amount: string}>,
+     * } $data
+     */
+    private function buildApiOrder(array $data): ApiOrder
+    {
+        $order = new ApiOrder(Mockery::mock(VatlyApiClient::class));
+        $order->id = $data['id'];
+        $order->customerId = $data['customerId'];
+        $order->total = new Money($data['currency'], $data['totalValue']);
+        $order->subtotal = new Money($data['currency'], $data['subtotalValue']);
+        $order->invoiceNumber = $data['invoiceNumber'];
+        $order->paymentMethod = $data['paymentMethod'];
+        $order->status = 'paid';
+        $order->taxSummary = new TaxSummaryCollection(array_map(
+            fn (array $rate) => [
+                'taxRate' => [
+                    'name' => $rate['name'],
+                    'percentage' => $rate['percentage'],
+                    'taxablePercentage' => $rate['taxablePercentage'],
+                ],
+                'amount' => ['currency' => $data['currency'], 'value' => $rate['amount']],
+            ],
+            $data['taxRates'],
+        ));
+
+        return $order;
     }
 
     public function test_it_cancels_a_subscription_immediately_from_webhook(): void


### PR DESCRIPTION
Bundles the OpenAPI-sync chore commit with a batch of dev-experience fixes uncovered while integrating Vatly into a Larafast-style app.

**Depends on:** vatly/vatly-fluent-php#22 — merge and tag `v0.6.0-alpha.1` first; this PR's composer pin is `0.6.0-alpha.1`.

## Summary

- **chore (`60e5256`)** — adopt the `UpdateSubscriptionBilling` action rename to mirror vatly/vatly-fluent-php#21 → vatly/vatly-api-php#16.
- **feat (`cd21bae`)** — five dev-XP fixes:
  1. **Migration stub idempotency** — `create_vatly_billable_columns.php.stub` now wraps adds with `Schema::hasColumn` guards and the `down()` drops the index before the column. Survives re-running `migrate` and Cashier-side `trial_ends_at` collisions. Covered by new `BillableColumnsMigrationTest`.
  2. **Tax breakdown persisted on orders** — wires up the new fluent `GetOrder` action; `EloquentOrderRepository` + `Order` model persist `subtotal` and `tax_summary` (JSON) from the enriched `OrderPaid` event. `vatly_orders` migration stub + tests fixture pick up the two new columns.
  3. **Service-provider wiring** — `GetOrder` registered as a singleton and threaded through `WebhookProcessorFactory::create(getOrder: ...)`.
  4. **Webhook controller test** for the end-to-end `order.paid` enrichment path.
  5. **Webhook route renamed** `webhook` → `vatly.webhook` so it stops squatting the global route-name namespace. **BC break:** consumers calling `route('webhook')` need to update.

### What changed vs the original plan
The original dev-XP-log plan also added a `vatly()` global helper for "trait-toggle apps". On reflection the package is positioned as a single integration per app (Cashier-style), so the helper had no distinct use case left — `\$user?->vatlyBillable()` covers the null-safety case. The helper was removed before opening this PR. The "Coexisting with Cashier" README section was dropped for the same reason.

### Composer
- Bumps `vatly/vatly-fluent-php` pin from `0.5.0-alpha.2` → `0.6.0-alpha.1` to pick up the new `GetOrder` + `OrderPaid` signature.

## Test plan
- [ ] Block merge until vatly-fluent-php#22 ships and tags `v0.6.0-alpha.1`
- [ ] `composer test` green (32 tests, 77 assertions)
- [ ] `composer analyse` green
- [ ] Smoke a fresh Larafast install: `vendor:publish --tag=vatly-billable-migrations` → `migrate` → run twice (idempotent)
- [ ] Trigger an `order.paid` webhook in test mode; verify the persisted order carries `subtotal` and a populated `tax_summary` JSON
