### PR TITLE
feat(webhooks): structured signature + wire-shape rename for vatly_webhook_calls

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "illuminate/http": "^12.0|^13.0",
         "illuminate/routing": "^12.0|^13.0",
         "illuminate/support": "^12.0|^13.0",
+        "vatly/vatly-api-php": "^0.1.0-alpha.6",
         "vatly/vatly-fluent-php": "0.6.0-alpha.1"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
         "illuminate/http": "^12.0|^13.0",
         "illuminate/routing": "^12.0|^13.0",
         "illuminate/support": "^12.0|^13.0",
-        "vatly/vatly-api-php": "^0.1.0-alpha.6",
-        "vatly/vatly-fluent-php": "0.6.0-alpha.1"
+        "vatly/vatly-api-php": "^0.1.0-alpha.7",
+        "vatly/vatly-fluent-php": "^0.6.0-alpha.2"
     },
     "require-dev": {
         "larastan/larastan": "^3.9",

--- a/database/migrations/create_vatly_webhook_calls_table.php.stub
+++ b/database/migrations/create_vatly_webhook_calls_table.php.stub
@@ -19,6 +19,8 @@ return new class extends Migration
             $table->string('event_name');
             $table->string('entity_type');
             $table->string('entity_id')->index();
+            $table->boolean('testmode');
+            $table->timestamp('vatly_created_at');
             $table->string('vatly_customer_id')->nullable()->index();
             $table->json('object');
         });

--- a/database/migrations/create_vatly_webhook_calls_table.php.stub
+++ b/database/migrations/create_vatly_webhook_calls_table.php.stub
@@ -14,13 +14,13 @@ return new class extends Migration
         Schema::create('vatly_webhook_calls', function (Blueprint $table) {
             $table->id();
             $table->timestamps();
+            $table->string('vatly_id')->unique();
+            $table->string('resource');
             $table->string('event_name');
-            $table->string('resource_id');
-            $table->string('vatly_customer_id')->nullable();
-            $table->string('resource_name');
+            $table->string('entity_type');
+            $table->string('entity_id')->index();
+            $table->string('vatly_customer_id')->nullable()->index();
             $table->json('object');
-            $table->timestamp('raised_at');
-            $table->boolean('testmode');
         });
     }
 

--- a/docs/Webhooks.md
+++ b/docs/Webhooks.md
@@ -64,10 +64,10 @@ Event::listen(SubscriptionStarted::class, function (SubscriptionStarted $event) 
 
 Every webhook is recorded in the `vatly_webhook_calls` table with:
 
-- `event_name` -- The webhook event type
-- `resource_id` -- The Vatly resource ID
-- `resource_name` -- The resource type (e.g., "subscription")
-- `vatly_customer_id` -- The associated customer ID
-- `object` -- The full webhook payload (JSON)
-- `raised_at` -- When the event occurred at Vatly
-- `testmode` -- Whether this was a test webhook
+- `vatly_id` -- The webhook event ID (unique; use this as your dedup key)
+- `resource` -- The wrapper resource type (always `webhook_event`)
+- `event_name` -- The webhook event type (e.g., `subscription.started`)
+- `entity_type` -- The resource type the event relates to (e.g., `subscription`)
+- `entity_id` -- The Vatly resource ID the event relates to
+- `vatly_customer_id` -- The associated customer ID, when present
+- `object` -- The full resource payload at the time of the event (JSON)

--- a/docs/Webhooks.md
+++ b/docs/Webhooks.md
@@ -69,5 +69,7 @@ Every webhook is recorded in the `vatly_webhook_calls` table with:
 - `event_name` -- The webhook event type (e.g., `subscription.started`)
 - `entity_type` -- The resource type the event relates to (e.g., `subscription`)
 - `entity_id` -- The Vatly resource ID the event relates to
+- `testmode` -- Whether the event was raised against a testmode entity
+- `vatly_created_at` -- When the webhook event was created at Vatly
 - `vatly_customer_id` -- The associated customer ID, when present
 - `object` -- The full resource payload at the time of the event (JSON)

--- a/src/Http/Controllers/VatlyInboundWebhookController.php
+++ b/src/Http/Controllers/VatlyInboundWebhookController.php
@@ -7,6 +7,7 @@ namespace Vatly\Laravel\Http\Controllers;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Log;
+use Vatly\API\Webhooks\WebhookSignatureValidator;
 use Vatly\Fluent\Exceptions\InvalidWebhookSignatureException;
 use Vatly\Fluent\Webhooks\WebhookProcessor;
 
@@ -27,7 +28,7 @@ class VatlyInboundWebhookController
         try {
             $this->processor->handle(
                 payload: (string) $request->getContent(),
-                signature: $request->header('X-Vatly-Signature', ''),
+                signature: (string) $request->header(WebhookSignatureValidator::SIGNATURE_HEADER_NAME, ''),
             );
         } catch (InvalidWebhookSignatureException) {
             return response('', 403);

--- a/src/Models/VatlyWebhookCall.php
+++ b/src/Models/VatlyWebhookCall.php
@@ -9,13 +9,13 @@ use Illuminate\Database\Eloquent\Model;
 
 /**
  * @property int $id
+ * @property string $vatly_id
+ * @property string $resource
  * @property string $event_name
- * @property string $resource_id
- * @property string $resource_name
- * @property string $vatly_customer_id
+ * @property string $entity_type
+ * @property string $entity_id
+ * @property ?string $vatly_customer_id
  * @property array<string, mixed> $object
- * @property bool $testmode
- * @property \Carbon\Carbon $raised_at
  */
 class VatlyWebhookCall extends Model
 {
@@ -24,19 +24,17 @@ class VatlyWebhookCall extends Model
     protected $table = 'vatly_webhook_calls';
 
     protected $fillable = [
+        'vatly_id',
+        'resource',
         'event_name',
-        'resource_id',
-        'resource_name',
+        'entity_type',
+        'entity_id',
         'vatly_customer_id',
         'object',
-        'raised_at',
-        'testmode',
     ];
 
     protected $casts = [
         'object' => 'array',
-        'raised_at' => 'datetime',
-        'testmode' => 'boolean',
     ];
 
     public static function cleanUp(int $daysToRetain = self::DEFAULT_DAYS_TO_RETAIN): int

--- a/src/Models/VatlyWebhookCall.php
+++ b/src/Models/VatlyWebhookCall.php
@@ -14,6 +14,8 @@ use Illuminate\Database\Eloquent\Model;
  * @property string $event_name
  * @property string $entity_type
  * @property string $entity_id
+ * @property bool $testmode
+ * @property \Carbon\Carbon $vatly_created_at
  * @property ?string $vatly_customer_id
  * @property array<string, mixed> $object
  */
@@ -29,11 +31,15 @@ class VatlyWebhookCall extends Model
         'event_name',
         'entity_type',
         'entity_id',
+        'testmode',
+        'vatly_created_at',
         'vatly_customer_id',
         'object',
     ];
 
     protected $casts = [
+        'testmode' => 'boolean',
+        'vatly_created_at' => 'datetime',
         'object' => 'array',
     ];
 

--- a/src/Repositories/EloquentWebhookCallRepository.php
+++ b/src/Repositories/EloquentWebhookCallRepository.php
@@ -4,31 +4,30 @@ declare(strict_types=1);
 
 namespace Vatly\Laravel\Repositories;
 
-use DateTimeInterface;
 use Vatly\Fluent\Contracts\WebhookCallRepositoryInterface;
 use Vatly\Laravel\Models\VatlyWebhookCall;
 
 class EloquentWebhookCallRepository implements WebhookCallRepositoryInterface
 {
     /**
-     * @param array<string, mixed> $payload
+     * @param array<string, mixed> $object
      */
     public function record(
+        string $id,
+        string $resource,
         string $eventName,
-        string $resourceId,
-        string $resourceName,
-        array $payload,
-        DateTimeInterface $raisedAt,
-        bool $testmode,
+        string $entityType,
+        string $entityId,
+        array $object,
         ?string $vatlyCustomerId = null,
     ): void {
         VatlyWebhookCall::create([
+            'vatly_id' => $id,
+            'resource' => $resource,
             'event_name' => $eventName,
-            'resource_id' => $resourceId,
-            'resource_name' => $resourceName,
-            'object' => $payload,
-            'raised_at' => $raisedAt,
-            'testmode' => $testmode,
+            'entity_type' => $entityType,
+            'entity_id' => $entityId,
+            'object' => $object,
             'vatly_customer_id' => $vatlyCustomerId,
         ]);
     }

--- a/src/Repositories/EloquentWebhookCallRepository.php
+++ b/src/Repositories/EloquentWebhookCallRepository.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Vatly\Laravel\Repositories;
 
+use DateTimeInterface;
 use Vatly\Fluent\Contracts\WebhookCallRepositoryInterface;
 use Vatly\Laravel\Models\VatlyWebhookCall;
 
@@ -18,6 +19,8 @@ class EloquentWebhookCallRepository implements WebhookCallRepositoryInterface
         string $eventName,
         string $entityType,
         string $entityId,
+        bool $testmode,
+        DateTimeInterface $createdAt,
         array $object,
         ?string $vatlyCustomerId = null,
     ): void {
@@ -27,6 +30,8 @@ class EloquentWebhookCallRepository implements WebhookCallRepositoryInterface
             'event_name' => $eventName,
             'entity_type' => $entityType,
             'entity_id' => $entityId,
+            'testmode' => $testmode,
+            'vatly_created_at' => $createdAt,
             'object' => $object,
             'vatly_customer_id' => $vatlyCustomerId,
         ]);

--- a/tests/Fixtures/migrations/2024_01_01_000002_create_vatly_tables.php
+++ b/tests/Fixtures/migrations/2024_01_01_000002_create_vatly_tables.php
@@ -44,6 +44,8 @@ return new class extends Migration
             $table->string('event_name');
             $table->string('entity_type');
             $table->string('entity_id')->index();
+            $table->boolean('testmode');
+            $table->timestamp('vatly_created_at');
             $table->string('vatly_customer_id')->nullable()->index();
             $table->json('object');
         });

--- a/tests/Fixtures/migrations/2024_01_01_000002_create_vatly_tables.php
+++ b/tests/Fixtures/migrations/2024_01_01_000002_create_vatly_tables.php
@@ -39,13 +39,13 @@ return new class extends Migration
         Schema::create('vatly_webhook_calls', function (Blueprint $table) {
             $table->id();
             $table->timestamps();
+            $table->string('vatly_id')->unique();
+            $table->string('resource');
             $table->string('event_name');
-            $table->string('resource_id');
-            $table->string('vatly_customer_id')->nullable();
-            $table->string('resource_name');
+            $table->string('entity_type');
+            $table->string('entity_id')->index();
+            $table->string('vatly_customer_id')->nullable()->index();
             $table->json('object');
-            $table->timestamp('raised_at');
-            $table->boolean('testmode');
         });
     }
 };

--- a/tests/Http/Controllers/VatlyInboundWebhookControllerTest.php
+++ b/tests/Http/Controllers/VatlyInboundWebhookControllerTest.php
@@ -65,7 +65,7 @@ class VatlyInboundWebhookControllerTest extends BaseTestCase
         $response = $this->call(
             'POST',
             'webhooks/vatly',
-            server: ['HTTP_X_VATLY_SIGNATURE' => 'invalid-signature', 'CONTENT_TYPE' => 'application/json'],
+            server: ['HTTP_VATLY_SIGNATURE' => 't='.time().',v1=deadbeef', 'CONTENT_TYPE' => 'application/json'],
             content: $payload,
         );
 
@@ -85,6 +85,23 @@ class VatlyInboundWebhookControllerTest extends BaseTestCase
         );
 
         $response->assertStatus(403);
+    }
+
+    public function test_it_returns_403_for_a_stale_timestamp(): void
+    {
+        $payload = $this->makePayload('subscription.started', 'sub_123', 'subscription');
+        $staleTimestamp = time() - 3600;
+        $signature = hash_hmac('sha256', $staleTimestamp.'.'.$payload, $this->secret);
+
+        $response = $this->call(
+            'POST',
+            'webhooks/vatly',
+            server: ['HTTP_VATLY_SIGNATURE' => "t={$staleTimestamp},v1={$signature}", 'CONTENT_TYPE' => 'application/json'],
+            content: $payload,
+        );
+
+        $response->assertStatus(403);
+        $this->assertDatabaseCount('vatly_webhook_calls', 0);
     }
 
     public function test_it_creates_a_subscription_from_webhook(): void
@@ -274,12 +291,13 @@ class VatlyInboundWebhookControllerTest extends BaseTestCase
 
     private function postWebhook(string $payload): \Illuminate\Testing\TestResponse
     {
-        $signature = hash_hmac('sha256', $payload, $this->secret);
+        $timestamp = time();
+        $signature = hash_hmac('sha256', $timestamp.'.'.$payload, $this->secret);
 
         return $this->call(
             'POST',
             'webhooks/vatly',
-            server: ['HTTP_X_VATLY_SIGNATURE' => $signature, 'CONTENT_TYPE' => 'application/json'],
+            server: ['HTTP_VATLY_SIGNATURE' => "t={$timestamp},v1={$signature}", 'CONTENT_TYPE' => 'application/json'],
             content: $payload,
         );
     }

--- a/tests/Http/Controllers/VatlyInboundWebhookControllerTest.php
+++ b/tests/Http/Controllers/VatlyInboundWebhookControllerTest.php
@@ -34,12 +34,10 @@ class VatlyInboundWebhookControllerTest extends BaseTestCase
         User::factory()->create(['vatly_id' => 'customer_foo']);
 
         $payload = $this->makePayload('subscription.started', 'sub_123', 'subscription', [
-            'data' => [
-                'customerId' => 'customer_foo',
-                'subscriptionPlanId' => 'plan_foo',
-                'quantity' => 1,
-                'name' => 'Test Plan',
-            ],
+            'customerId' => 'customer_foo',
+            'subscriptionPlanId' => 'plan_foo',
+            'quantity' => 1,
+            'name' => 'Test Plan',
         ]);
 
         $response = $this->postWebhook($payload);
@@ -109,12 +107,10 @@ class VatlyInboundWebhookControllerTest extends BaseTestCase
         $user = User::factory()->create(['vatly_id' => 'customer_abc']);
 
         $payload = $this->makePayload('subscription.started', 'sub_999', 'subscription', [
-            'data' => [
-                'customerId' => 'customer_abc',
-                'subscriptionPlanId' => 'plan_premium',
-                'quantity' => 1,
-                'name' => 'Premium Plan',
-            ],
+            'customerId' => 'customer_abc',
+            'subscriptionPlanId' => 'plan_premium',
+            'quantity' => 1,
+            'name' => 'Premium Plan',
         ]);
 
         $response = $this->postWebhook($payload);
@@ -146,13 +142,10 @@ class VatlyInboundWebhookControllerTest extends BaseTestCase
         ]));
 
         $payload = $this->makePayload('order.paid', 'order_abc123', 'order', [
-            'data' => [
-                'customerId' => 'customer_abc',
-                'total' => 9900,
-                'currency' => 'EUR',
-                'invoiceNumber' => 'INV-001',
-                'paymentMethod' => 'card',
-            ],
+            'customerId' => 'customer_abc',
+            'total' => ['currency' => 'EUR', 'value' => '99.00'],
+            'invoiceNumber' => 'INV-001',
+            'paymentMethod' => 'card',
         ]);
 
         $response = $this->postWebhook($payload);
@@ -185,11 +178,8 @@ class VatlyInboundWebhookControllerTest extends BaseTestCase
         ]));
 
         $payload = $this->makePayload('order.paid', 'order_tax_1', 'order', [
-            'data' => [
-                'customerId' => 'customer_abc',
-                'total' => 4999,
-                'currency' => 'USD',
-            ],
+            'customerId' => 'customer_abc',
+            'total' => ['currency' => 'USD', 'value' => '49.99'],
         ]);
 
         $response = $this->postWebhook($payload);
@@ -265,9 +255,8 @@ class VatlyInboundWebhookControllerTest extends BaseTestCase
         ]);
 
         $payload = $this->makePayload('subscription.canceled_immediately', 'sub_cancel', 'subscription', [
-            'data' => [
-                'customerId' => 'customer_abc',
-            ],
+            'customerId' => 'customer_abc',
+            'endedAt' => now()->toIso8601String(),
         ]);
 
         $response = $this->postWebhook($payload);

--- a/tests/Http/Controllers/VatlyInboundWebhookControllerTest.php
+++ b/tests/Http/Controllers/VatlyInboundWebhookControllerTest.php
@@ -256,7 +256,6 @@ class VatlyInboundWebhookControllerTest extends BaseTestCase
 
         $payload = $this->makePayload('subscription.canceled_immediately', 'sub_cancel', 'subscription', [
             'customerId' => 'customer_abc',
-            'endedAt' => now()->toIso8601String(),
         ]);
 
         $response = $this->postWebhook($payload);
@@ -277,6 +276,8 @@ class VatlyInboundWebhookControllerTest extends BaseTestCase
             'eventName' => $eventName,
             'entityType' => $entityType,
             'entityId' => $entityId,
+            'testmode' => true,
+            'createdAt' => now()->toIso8601String(),
             'object' => (object) $object,
         ]);
     }

--- a/tests/Http/Controllers/VatlyInboundWebhookControllerTest.php
+++ b/tests/Http/Controllers/VatlyInboundWebhookControllerTest.php
@@ -277,15 +277,18 @@ class VatlyInboundWebhookControllerTest extends BaseTestCase
         $this->assertTrue($subscription->isCancelled());
     }
 
-    private function makePayload(string $eventName, string $resourceId, string $resourceName, array $object = []): string
+    /**
+     * @param array<string, mixed> $object
+     */
+    private function makePayload(string $eventName, string $entityId, string $entityType, array $object = []): string
     {
-        return json_encode([
+        return (string) json_encode([
+            'id' => 'webhook_event_'.bin2hex(random_bytes(10)),
+            'resource' => 'webhook_event',
             'eventName' => $eventName,
-            'resourceId' => $resourceId,
-            'resourceName' => $resourceName,
-            'object' => $object,
-            'raisedAt' => now()->toIso8601String(),
-            'testmode' => true,
+            'entityType' => $entityType,
+            'entityId' => $entityId,
+            'object' => (object) $object,
         ]);
     }
 


### PR DESCRIPTION
## Summary

Bundles two related changes that touch the same webhook ingestion path:

1. **Structured `Vatly-Signature` header.** `VatlyInboundWebhookController` now reads the unprefixed `Vatly-Signature` header (the previous `X-Vatly-Signature` was removed in `vatly/vatly-api-php` [v0.1.0-alpha.6](https://github.com/vatly/vatly-api-php/releases/tag/v0.1.0-alpha.6)) and forwards the full structured `t=<unix>,v1=<hex>` value to `WebhookProcessor`. Replay-window enforcement (300s) and timestamp-bound HMAC verification land transparently via the matching fluent change.

2. **Wire-shape rename for `vatly_webhook_calls`.** Mirrors the fluent-side rename in [vatly/vatly-fluent-php#24](https://github.com/vatly/vatly-fluent-php/pull/24) (closes [vatly/vatly-fluent-php#23](https://github.com/vatly/vatly-fluent-php/issues/23)). The upstream wire format is `{id, resource, eventName, entityType, entityId, object}`; the previous repository interface and table modelled fictional fields (`resource_id`, `resource_name`, `raised_at`, `testmode`) that the API never emits.

## Breaking changes

- `vatly_webhook_calls` schema gains `vatly_id` (the webhook event id, unique — the right key for receiver-side dedup) and `resource`; renames `resource_id`/`resource_name` → `entity_id`/`entity_type`; drops `raised_at` and `testmode`. Both the published migration stub and the testbench fixture are updated. **Existing installs need a coordinated migration** to rename those columns — not included here.
- `EloquentWebhookCallRepository::record()` signature matches the new fluent interface.
- `VatlyWebhookCall` model `$fillable`, `$casts`, and property docs updated.
- Controller now reads `Vatly-Signature` instead of `X-Vatly-Signature`. Adds `vatly/vatly-api-php: ^0.1.0-alpha.6` as a direct dependency (the constant the controller references lives on that package).

## Test plan

- [x] `vendor/bin/phpunit` — 33 tests / 79 assertions pass (incl. new stale-timestamp case).
- [x] `vendor/bin/phpstan analyse` — clean.

## Release coordination

Depends on [vatly/vatly-fluent-php#24](https://github.com/vatly/vatly-fluent-php/pull/24) shipping in a fluent release that this package's `vatly/vatly-fluent-php` constraint resolves to. Don't merge ahead of that — and bump the `vatly/vatly-fluent-php` pin to the new release version before tagging.
