### PR TITLE
feat: wire ResumeSubscription action through the container

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "illuminate/http": "^12.0|^13.0",
         "illuminate/routing": "^12.0|^13.0",
         "illuminate/support": "^12.0|^13.0",
-        "vatly/vatly-api-php": "^0.1.0-alpha.7",
+        "vatly/vatly-api-php": "^0.1.0-alpha.8",
         "vatly/vatly-fluent-php": "^0.6.0-alpha.2"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "illuminate/routing": "^12.0|^13.0",
         "illuminate/support": "^12.0|^13.0",
         "vatly/vatly-api-php": "^0.1.0-alpha.8",
-        "vatly/vatly-fluent-php": "^0.6.0-alpha.2"
+        "vatly/vatly-fluent-php": "^0.6.0-alpha.3"
     },
     "require-dev": {
         "larastan/larastan": "^3.9",

--- a/src/Repositories/EloquentSubscriptionRepository.php
+++ b/src/Repositories/EloquentSubscriptionRepository.php
@@ -83,6 +83,8 @@ class EloquentSubscriptionRepository implements SubscriptionRepositoryInterface
             }
             if ($data->endsAt !== null) {
                 $subscription->ends_at = Carbon::instance($data->endsAt);
+            } elseif ($data->clearEndsAt) {
+                $subscription->ends_at = null;
             }
             $subscription->save();
         }

--- a/src/VatlyServiceProvider.php
+++ b/src/VatlyServiceProvider.php
@@ -14,6 +14,7 @@ use Vatly\Fluent\Actions\GetCheckout;
 use Vatly\Fluent\Actions\GetCustomer;
 use Vatly\Fluent\Actions\GetOrder;
 use Vatly\Fluent\Actions\GetSubscription;
+use Vatly\Fluent\Actions\ResumeSubscription;
 use Vatly\Fluent\Actions\SwapSubscriptionPlan;
 use Vatly\Fluent\BillableFactory;
 use Vatly\Fluent\Contracts\ConfigurationInterface;
@@ -85,6 +86,7 @@ class VatlyServiceProvider extends ServiceProvider
             GetSubscription::class,
             UpdateSubscriptionBilling::class,
             CancelSubscription::class,
+            ResumeSubscription::class,
             SwapSubscriptionPlan::class,
         ];
 
@@ -122,6 +124,7 @@ class VatlyServiceProvider extends ServiceProvider
                 getSubscriptionAction: $this->app->make(GetSubscription::class),
                 swapSubscriptionPlanAction: $this->app->make(SwapSubscriptionPlan::class),
                 cancelSubscriptionAction: $this->app->make(CancelSubscription::class),
+                resumeSubscriptionAction: $this->app->make(ResumeSubscription::class),
                 updateBillingAction: $this->app->make(UpdateSubscriptionBilling::class),
             );
         });


### PR DESCRIPTION
## Summary
- Registers the new fluent `ResumeSubscription` action as a singleton and passes it to `BillableFactory`, so `$user->subscription()->resume()` works end-to-end.
- `EloquentSubscriptionRepository::update()` honors the new `clearEndsAt` flag from `UpdateSubscriptionData` — clearing the `ends_at` column when the fluent handle resumes a grace-period subscription.
- Bumps `vatly/vatly-api-php` to `^0.1.0-alpha.8`.

## Files
- `src/VatlyServiceProvider.php` — register `ResumeSubscription` in the actions singleton list and pass it into `BillableFactory`.
- `src/Repositories/EloquentSubscriptionRepository.php` — `update()` clears `ends_at` when `clearEndsAt === true`.
- `composer.json` — `vatly/vatly-api-php: ^0.1.0-alpha.8`.

## Test plan
- [x] Syntax check on modified files
- [ ] Full `vendor/bin/phpunit` will pass once `vatly/vatly-fluent-php` ships a tag containing `Actions\ResumeSubscription` and the constraint here is bumped to it
- [ ] Manual: `$user->subscription()->resume()` flips `ends_at` to null in the DB

## Upstream
- https://github.com/vatly/vatly-api-php/releases/tag/v0.1.0-alpha.8 (merged + published)
- https://github.com/vatly/vatly-fluent-php/pull/27 (needs to merge + release before this is mergeable)

## Note
There's a pre-existing fatal in `EloquentWebhookCallRepository::record()` (signature mismatch with `WebhookCallRepositoryInterface::record()`) that prevents the full test suite from running on `main`. Unrelated to this change.
