### PR TITLE
feat: subscription.resume support (drops direct vatly-api-php dep)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,7 @@
         "illuminate/http": "^12.0|^13.0",
         "illuminate/routing": "^12.0|^13.0",
         "illuminate/support": "^12.0|^13.0",
-        "vatly/vatly-api-php": "^0.1.0-alpha.7",
-        "vatly/vatly-fluent-php": "^0.6.0-alpha.2"
+        "vatly/vatly-fluent-php": "^0.6.0-alpha.4"
     },
     "require-dev": {
         "larastan/larastan": "^3.9",

--- a/src/Http/Controllers/VatlyInboundWebhookController.php
+++ b/src/Http/Controllers/VatlyInboundWebhookController.php
@@ -7,8 +7,8 @@ namespace Vatly\Laravel\Http\Controllers;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Log;
-use Vatly\API\Webhooks\WebhookSignatureValidator;
 use Vatly\Fluent\Exceptions\InvalidWebhookSignatureException;
+use Vatly\Fluent\Webhooks\SignatureVerifier;
 use Vatly\Fluent\Webhooks\WebhookProcessor;
 
 class VatlyInboundWebhookController
@@ -28,7 +28,7 @@ class VatlyInboundWebhookController
         try {
             $this->processor->handle(
                 payload: (string) $request->getContent(),
-                signature: (string) $request->header(WebhookSignatureValidator::SIGNATURE_HEADER_NAME, ''),
+                signature: (string) $request->header(SignatureVerifier::SIGNATURE_HEADER_NAME, ''),
             );
         } catch (InvalidWebhookSignatureException) {
             return response('', 403);

--- a/src/Repositories/EloquentSubscriptionRepository.php
+++ b/src/Repositories/EloquentSubscriptionRepository.php
@@ -83,6 +83,8 @@ class EloquentSubscriptionRepository implements SubscriptionRepositoryInterface
             }
             if ($data->endsAt !== null) {
                 $subscription->ends_at = Carbon::instance($data->endsAt);
+            } elseif ($data->clearEndsAt) {
+                $subscription->ends_at = null;
             }
             $subscription->save();
         }

--- a/src/VatlyServiceProvider.php
+++ b/src/VatlyServiceProvider.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Vatly\Laravel;
 
 use Illuminate\Support\ServiceProvider;
-use Vatly\API\VatlyApiClient;
 use Vatly\Fluent\Actions\CancelSubscription;
 use Vatly\Fluent\Actions\CreateCheckout;
 use Vatly\Fluent\Actions\CreateCustomer;
@@ -14,6 +13,7 @@ use Vatly\Fluent\Actions\GetCheckout;
 use Vatly\Fluent\Actions\GetCustomer;
 use Vatly\Fluent\Actions\GetOrder;
 use Vatly\Fluent\Actions\GetSubscription;
+use Vatly\Fluent\Actions\ResumeSubscription;
 use Vatly\Fluent\Actions\SwapSubscriptionPlan;
 use Vatly\Fluent\BillableFactory;
 use Vatly\Fluent\Contracts\ConfigurationInterface;
@@ -22,6 +22,7 @@ use Vatly\Fluent\Contracts\EventDispatcherInterface;
 use Vatly\Fluent\Contracts\OrderRepositoryInterface;
 use Vatly\Fluent\Contracts\SubscriptionRepositoryInterface;
 use Vatly\Fluent\Contracts\WebhookCallRepositoryInterface;
+use Vatly\Fluent\Vatly;
 use Vatly\Fluent\Webhooks\WebhookProcessor;
 use Vatly\Fluent\Webhooks\WebhookProcessorFactory;
 use Vatly\Laravel\Events\LaravelEventDispatcher;
@@ -61,15 +62,21 @@ class VatlyServiceProvider extends ServiceProvider
 
     private function registerApiClient(): void
     {
-        $this->app->singleton(VatlyApiClient::class, function () {
+        // Build the API client through fluent's Vatly facade so we don't take
+        // a direct dependency on vatly/vatly-api-php. The actions all expect
+        // a VatlyApiClient — we expose the one Vatly owns under its FQCN.
+        $this->app->singleton(Vatly::class, function () {
             $config = $this->app->make(ConfigurationInterface::class);
 
-            $client = new VatlyApiClient();
-            $client->setApiKey($config->getApiKey());
-            $client->setApiEndpoint($config->getApiUrl());
-            $client->setApiVersion($config->getApiVersion());
+            return new Vatly(
+                apiKey: $config->getApiKey(),
+                apiEndpoint: $config->getApiUrl(),
+                apiVersion: $config->getApiVersion(),
+            );
+        });
 
-            return $client;
+        $this->app->singleton(\Vatly\API\VatlyApiClient::class, function () {
+            return $this->app->make(Vatly::class)->getApiClient();
         });
     }
 
@@ -85,12 +92,13 @@ class VatlyServiceProvider extends ServiceProvider
             GetSubscription::class,
             UpdateSubscriptionBilling::class,
             CancelSubscription::class,
+            ResumeSubscription::class,
             SwapSubscriptionPlan::class,
         ];
 
         foreach ($actions as $action) {
             $this->app->singleton($action, function () use ($action) {
-                return new $action($this->app->make(VatlyApiClient::class));
+                return new $action($this->app->make(\Vatly\API\VatlyApiClient::class));
             });
         }
     }
@@ -122,6 +130,7 @@ class VatlyServiceProvider extends ServiceProvider
                 getSubscriptionAction: $this->app->make(GetSubscription::class),
                 swapSubscriptionPlanAction: $this->app->make(SwapSubscriptionPlan::class),
                 cancelSubscriptionAction: $this->app->make(CancelSubscription::class),
+                resumeSubscriptionAction: $this->app->make(ResumeSubscription::class),
                 updateBillingAction: $this->app->make(UpdateSubscriptionBilling::class),
             );
         });


### PR DESCRIPTION
## Summary
Single PR covering the full `subscription.resume` story on the Laravel side, *and* cleaning up the dependency graph so this package no longer takes a direct `vatly/vatly-api-php` dependency.

After this lands, the dependency chain is cleanly layered:

```
vatly-laravel → vatly-fluent-php → vatly-api-php
```

so the api SDK can evolve without bumping `vatly-laravel`'s direct constraint.

## What changed

**`src/VatlyServiceProvider.php`**
- Drops `use Vatly\API\VatlyApiClient`. The provider now constructs `Vatly\Fluent\Vatly` (passing apiKey/endpoint/version through fluent's new constructor args) and binds the `VatlyApiClient` slot — used by the action constructors — to `Vatly::getApiClient()`. The remaining `VatlyApiClient::class` reference is inline FQCN, no `use` statement.
- Registers the new `Vatly\Fluent\Actions\ResumeSubscription` action and passes it into `BillableFactory` (required by fluent since v0.6.0-alpha.3).

**`src/Repositories/EloquentSubscriptionRepository.php`**
- `update()` honors the new `UpdateSubscriptionData::$clearEndsAt` flag — clears `ends_at` when resume is in progress so `isActive()` flips back to true without waiting for the resumed webhook.

**`src/Http/Controllers/VatlyInboundWebhookController.php`**
- `Vatly\API\Webhooks\WebhookSignatureValidator::SIGNATURE_HEADER_NAME` → `Vatly\Fluent\Webhooks\SignatureVerifier::SIGNATURE_HEADER_NAME` (re-exported in fluent v0.6.0-alpha.4).

**`composer.json`**
- Drops `vatly/vatly-api-php` (still resolved transitively through fluent).
- Bumps `vatly/vatly-fluent-php` to `^0.6.0-alpha.4`.

**Kept**
- `Billable.php` still imports `Vatly\API\Resources\Customer` for return-type clarity. Composer is fine with this (transitive resolution); PHPStan level 6 doesn't enforce direct deps.

## Test plan
- [x] `vendor/bin/phpunit` — 33/33 pass (verified against a local fluent path repo containing the alpha.4 changes)
- [x] `vendor/bin/phpstan analyse` — clean
- [ ] Will go green on CI once fluent v0.6.0-alpha.4 ships

## Depends on
- https://github.com/vatly/vatly-fluent-php/pull/28 — must merge + release as v0.6.0-alpha.4 before this is mergeable

## Supersedes
- #20 (resume wiring + `clearEndsAt` repo change rolled into this PR)
