### PR TITLE
fix: honor UpdateSubscriptionData::$clearEndsAt in eloquent repo

### DIFF
--- a/src/Repositories/EloquentSubscriptionRepository.php
+++ b/src/Repositories/EloquentSubscriptionRepository.php
@@ -59,6 +59,8 @@ class EloquentSubscriptionRepository implements SubscriptionRepositoryInterface
             }
             if ($data->endsAt !== null) {
                 $subscription->ends_at = Carbon::instance($data->endsAt);
+            } elseif ($data->clearEndsAt) {
+                $subscription->ends_at = null;
             }
             $subscription->save();
         }

--- a/tests/Repositories/EloquentSubscriptionRepositoryTest.php
+++ b/tests/Repositories/EloquentSubscriptionRepositoryTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Laravel\Tests\Repositories;
+
+use Carbon\CarbonImmutable;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Vatly\Fluent\Data\UpdateSubscriptionData;
+use Vatly\Laravel\Models\Subscription;
+use Vatly\Laravel\Repositories\EloquentSubscriptionRepository;
+use Vatly\Laravel\Tests\BaseTestCase;
+
+class EloquentSubscriptionRepositoryTest extends BaseTestCase
+{
+    use RefreshDatabase;
+
+    private EloquentSubscriptionRepository $repo;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->repo = $this->app->make(EloquentSubscriptionRepository::class);
+    }
+
+    public function test_update_with_clear_ends_at_nulls_the_column(): void
+    {
+        $subscription = $this->makeSubscription([
+            'ends_at' => CarbonImmutable::parse('2026-06-01T00:00:00+00:00'),
+        ]);
+
+        $this->repo->update($subscription, new UpdateSubscriptionData(
+            planId: 'plan_basic',
+            quantity: 1,
+            clearEndsAt: true,
+        ));
+
+        $this->assertNull($subscription->fresh()->ends_at);
+    }
+
+    public function test_update_with_ends_at_sets_the_column(): void
+    {
+        $subscription = $this->makeSubscription(['ends_at' => null]);
+
+        $endsAt = CarbonImmutable::parse('2026-07-15T12:00:00+00:00');
+
+        $this->repo->update($subscription, new UpdateSubscriptionData(
+            endsAt: $endsAt,
+        ));
+
+        $this->assertSame(
+            $endsAt->format('Y-m-d H:i:s'),
+            $subscription->fresh()->ends_at->format('Y-m-d H:i:s'),
+        );
+    }
+
+    public function test_update_ignores_clear_ends_at_when_ends_at_is_also_provided(): void
+    {
+        // endsAt wins — clearEndsAt is the "no replacement value" signal,
+        // not "force-null even if a replacement was given".
+        $subscription = $this->makeSubscription(['ends_at' => null]);
+
+        $endsAt = CarbonImmutable::parse('2026-08-01T00:00:00+00:00');
+
+        $this->repo->update($subscription, new UpdateSubscriptionData(
+            endsAt: $endsAt,
+            clearEndsAt: true,
+        ));
+
+        $this->assertNotNull($subscription->fresh()->ends_at);
+        $this->assertSame(
+            $endsAt->format('Y-m-d H:i:s'),
+            $subscription->fresh()->ends_at->format('Y-m-d H:i:s'),
+        );
+    }
+
+    public function test_update_leaves_ends_at_alone_when_neither_flag_is_set(): void
+    {
+        $existing = CarbonImmutable::parse('2026-09-01T00:00:00+00:00');
+
+        $subscription = $this->makeSubscription(['ends_at' => $existing]);
+
+        $this->repo->update($subscription, new UpdateSubscriptionData(
+            planId: 'plan_premium',
+        ));
+
+        $this->assertSame(
+            $existing->format('Y-m-d H:i:s'),
+            $subscription->fresh()->ends_at->format('Y-m-d H:i:s'),
+        );
+        $this->assertSame('plan_premium', $subscription->fresh()->plan_id);
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function makeSubscription(array $overrides = []): Subscription
+    {
+        return Subscription::create(array_merge([
+            'type' => 'default',
+            'plan_id' => 'plan_basic',
+            'vatly_id' => 'subscription_'.bin2hex(random_bytes(8)),
+            'name' => 'Test subscription',
+            'quantity' => 1,
+        ], $overrides));
+    }
+}


### PR DESCRIPTION
## Summary
Closes the local-state gap when `$user->subscription()->resume()` is called.

`Vatly\Fluent\SubscriptionHandle::resume()` already passes `clearEndsAt: true` on the `UpdateSubscriptionData` it hands to the repository — the API call succeeds and fluent expects the driver to null out the local `ends_at` column so `isActive()` flips back to true without waiting for the resumed webhook.

The Eloquent driver was ignoring that flag: `endsAt: null` was treated as "leave alone" (correct for swap/sync/cancel webhook reactions), but there was no branch handling the explicit clear signal.

Two-line `elseif` added so:
- `endsAt: $date` → set column to `$date` (unchanged behavior)
- `endsAt: null, clearEndsAt: true` → null the column
- `endsAt: $date, clearEndsAt: true` → set to `$date` (endsAt wins — `clearEndsAt` is the "no replacement value" signal, not "force null")
- `endsAt: null, clearEndsAt: false` → leave alone (unchanged behavior)

## Background
This fix originally rode along with the (now-closed) #20 / #21 chain on the resume work, but was lost when #21 was superseded by #22 (#22 didn't touch `EloquentSubscriptionRepository`). Caught during a follow-up audit.

## Files
- `src/Repositories/EloquentSubscriptionRepository.php` — two-line `elseif` branch.
- `tests/Repositories/EloquentSubscriptionRepositoryTest.php` (new) — covers all four cases above.

## Test plan
- [x] `vendor/bin/phpunit tests/Repositories/EloquentSubscriptionRepositoryTest.php` — 4/4 pass
- [x] `vendor/bin/phpunit` (full suite) — 54/54 pass
- [x] Verified the `clearEndsAt` test fails without the src change (1/4 failures, as expected)
