### PR TITLE
Adopt vatly-fluent-php v0.8.0-alpha.4 (payment.failed handling + webhook docs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,8 @@ Event::listen(OrderPaid::class, function (OrderPaid $event) {
 
 Events available:
 
-- `Vatly\Fluent\Events\WebhookReceived`
 - `Vatly\Fluent\Events\OrderPaid` — carries `total`, `subtotal`, `taxSummary` (full per-rate breakdown), `currency`, `invoiceNumber`, `paymentMethod`. Materialize local invoices without an extra API call.
+- `Vatly\Fluent\Events\PaymentFailed` — same enriched order shape as `OrderPaid`; typically the start of dunning.
 - `Vatly\Fluent\Events\SubscriptionStarted`
 - `Vatly\Fluent\Events\SubscriptionCanceledImmediately`
 - `Vatly\Fluent\Events\SubscriptionCanceledWithGracePeriod`

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "illuminate/http": "^12.0|^13.0",
         "illuminate/routing": "^12.0|^13.0",
         "illuminate/support": "^12.0|^13.0",
-        "vatly/vatly-fluent-php": "^0.8.0-alpha.1"
+        "vatly/vatly-fluent-php": "^0.8.0-alpha.4"
     },
     "require-dev": {
         "larastan/larastan": "^3.9",

--- a/docs/Webhooks.md
+++ b/docs/Webhooks.md
@@ -26,37 +26,66 @@ Exclude the webhook route from CSRF verification. In Laravel 11+, this is typica
 
 ## Events
 
-When a webhook is received, Vatly Laravel dispatches typed events that you can listen to:
+When a webhook is received, the driver's `LaravelEventDispatcher` forwards fluent's typed domain events straight onto Laravel's event bus, so you listen for the fluent classes directly. They all live under the `Vatly\Fluent\Events\` namespace:
 
-| Event | Description |
+| Event (`Vatly\Fluent\Events\…`) | Dispatched when |
 | --- | --- |
-| `WebhookReceived` | Raw webhook received (dispatched for every webhook) |
-| `SubscriptionStarted` | A new subscription was activated |
-| `SubscriptionCanceledImmediately` | Subscription was canceled and ended immediately |
-| `SubscriptionCanceledWithGracePeriod` | Subscription was canceled but remains active until `ends_at` |
+| `SubscriptionStarted` | A `subscription.started` webhook is received |
+| `SubscriptionCanceledImmediately` | A `subscription.canceled_immediately` webhook is received |
+| `SubscriptionCanceledWithGracePeriod` | A `subscription.canceled_with_grace_period` webhook is received |
+| `OrderPaid` | An `order.paid` webhook is received (enriched with the full tax breakdown) |
+| `PaymentFailed` | A `payment.failed` webhook is received — typically the start of dunning (enriched with the full tax breakdown) |
+| `UnsupportedWebhookReceived` | A webhook arrives that has no typed mapping (carries the raw `eventName` / `object`) |
+| `LocalSubscriptionCreated` | A new local `Subscription` row was just created from a `subscription.started` webhook (application-level event; carries the stored `$subscription`) |
 
-## Built-in listeners
+Exactly one of the webhook events above is dispatched per incoming webhook (`UnsupportedWebhookReceived` is the fallback for unmapped events). `LocalSubscriptionCreated` fires additionally, from the subscription-sync reaction, only when a brand-new local row is created.
 
-The package includes listeners that automatically handle subscription lifecycle events:
+## Built-in reactions
 
-- **`StartSubscriptionListener`** -- Creates a local `Subscription` model when a subscription starts
-- **`CancelSubscriptionImmediatelyListener`** -- Sets `ends_at` to now when immediately canceled
-- **`CancelSubscriptionWithGracePeriodListener`** -- Sets `ends_at` to the grace period end date
+Before the event is dispatched, the package keeps your local tables in sync automatically via fluent's standard webhook *reactions*. These are wired by `WebhookProcessorFactory` inside the `Vatly` composition root — no registration needed on your side. They live under `Vatly\Fluent\Webhooks\Reactions\`:
+
+- **`SyncSubscriptionOnStarted`** -- On `SubscriptionStarted`, creates (or updates) the local `Subscription` row, then dispatches `LocalSubscriptionCreated` for newly-created rows.
+- **`CancelSubscriptionOnCanceled`** -- On `SubscriptionCanceledImmediately` / `SubscriptionCanceledWithGracePeriod`, sets the local subscription's `ends_at`.
+- **`StoreOrderOnPaid`** -- On `OrderPaid`, stores (or updates) the local `Order` row.
+- **`StoreOrderOnPaymentFailed`** -- On `PaymentFailed`, stores (or updates) the local `Order` row, mirroring the upstream order status verbatim.
 
 ## Custom listeners
 
-Listen for Vatly events in your `EventServiceProvider` or using the `Event` facade:
+Listen for the fluent events in your `EventServiceProvider` or using the `Event` facade:
 
 ```php
-use Vatly\Laravel\Events\SubscriptionStarted;
+use Illuminate\Support\Facades\Event;
+use Vatly\Fluent\Events\SubscriptionStarted;
 
 Event::listen(SubscriptionStarted::class, function (SubscriptionStarted $event) {
+    // $event->customerId
     // $event->subscriptionId
     // $event->planId
+    // $event->type
     // $event->name
     // $event->quantity
-    
+
     // Send welcome email, provision features, etc.
+});
+```
+
+Order events (`OrderPaid` / `PaymentFailed`) carry the full, API-enriched order — including the tax breakdown — so you can materialize an invoice without a follow-up API call:
+
+```php
+use Illuminate\Support\Facades\Event;
+use Vatly\Fluent\Events\OrderPaid;
+
+Event::listen(OrderPaid::class, function (OrderPaid $event) {
+    // $event->orderId
+    // $event->customerId
+    // $event->status
+    // $event->total      // minor units (cents)
+    // $event->subtotal   // minor units (cents)
+    // $event->currency
+    // $event->taxSummary
+    // $event->invoiceNumber
+    // $event->paymentMethod
+    // $event->metadata
 });
 ```
 

--- a/tests/Http/Controllers/VatlyInboundWebhookControllerTest.php
+++ b/tests/Http/Controllers/VatlyInboundWebhookControllerTest.php
@@ -6,6 +6,8 @@ namespace Vatly\Laravel\Tests\Http\Controllers;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+use Vatly\Fluent\Events\PaymentFailed;
 use Vatly\Laravel\Models\Order;
 use Vatly\Laravel\Models\Subscription;
 use Vatly\Laravel\Tests\BaseTestCase;
@@ -176,6 +178,76 @@ class VatlyInboundWebhookControllerTest extends BaseTestCase
         $this->assertSame(868, $order->tax_summary[0]['amount']);
         $this->assertSame('USD', $order->tax_summary[0]['currency']);
         $this->assertSame($user->id, $order->owner_id);
+    }
+
+    public function test_it_stores_an_order_when_a_payment_fails_from_webhook(): void
+    {
+        $user = User::factory()->create(['vatly_id' => 'customer_abc']);
+
+        $apiOrder = $this->buildApiOrder([
+            'id' => 'order_failed_1',
+            'customerId' => 'customer_abc',
+            'totalValue' => '99.00',
+            'subtotalValue' => '81.82',
+            'currency' => 'EUR',
+            'invoiceNumber' => 'INV-009',
+            'paymentMethod' => 'card',
+            'taxRates' => [
+                ['name' => 'VAT', 'percentage' => 21.0, 'taxablePercentage' => 100.0, 'amount' => '17.18'],
+            ],
+        ]);
+        // The reaction mirrors the upstream status verbatim — not a synthetic "failed".
+        $apiOrder->status = 'pending';
+        $this->fakeGetOrder($apiOrder);
+
+        $response = $this->postWebhookEvent('payment.failed', 'order_failed_1', 'order', [
+            'customerId' => 'customer_abc',
+            'total' => ['currency' => 'EUR', 'value' => '99.00'],
+            'invoiceNumber' => 'INV-009',
+            'paymentMethod' => 'card',
+        ]);
+
+        $response->assertStatus(201);
+        $this->assertDatabaseHas('vatly_orders', [
+            'vatly_id' => 'order_failed_1',
+            'status' => 'pending',
+            'total' => 9900,
+            'currency' => 'EUR',
+            'owner_id' => $user->id,
+        ]);
+    }
+
+    public function test_it_dispatches_the_payment_failed_event_from_webhook(): void
+    {
+        Event::fake([PaymentFailed::class]);
+
+        User::factory()->create(['vatly_id' => 'customer_abc']);
+
+        $apiOrder = $this->buildApiOrder([
+            'id' => 'order_failed_2',
+            'customerId' => 'customer_abc',
+            'totalValue' => '99.00',
+            'subtotalValue' => '81.82',
+            'currency' => 'EUR',
+            'invoiceNumber' => null,
+            'paymentMethod' => null,
+            'taxRates' => [
+                ['name' => 'VAT', 'percentage' => 21.0, 'taxablePercentage' => 100.0, 'amount' => '17.18'],
+            ],
+        ]);
+        $apiOrder->status = 'pending';
+        $this->fakeGetOrder($apiOrder);
+
+        $this->postWebhookEvent('payment.failed', 'order_failed_2', 'order', [
+            'customerId' => 'customer_abc',
+            'total' => ['currency' => 'EUR', 'value' => '99.00'],
+        ])->assertStatus(201);
+
+        Event::assertDispatched(
+            PaymentFailed::class,
+            fn (PaymentFailed $event): bool => $event->orderId === 'order_failed_2'
+                && $event->customerId === 'customer_abc',
+        );
     }
 
     public function test_it_cancels_a_subscription_immediately_from_webhook(): void


### PR DESCRIPTION
## What

Adopts [`vatly/vatly-fluent-php` v0.8.0-alpha.4](https://github.com/vatly/vatly-fluent-php/releases/tag/v0.8.0-alpha.4). Bumps the constraint floor `^0.8.0-alpha.1` → `^0.8.0-alpha.4`, resolving fluent `v0.8.0-alpha.4` + api `v0.1.0-alpha.10`.

## Why this is more than a version bump

The driver was written against **alpha.2**, so adopting alpha.4 pulls in **alpha.3** too. I checked every upstream change against the driver:

| Upstream change | Impact |
| --- | --- |
| **`payment.failed` now routed** (alpha.3): typed `PaymentFailed` event + `StoreOrderOnPaymentFailed` reaction in the fixed wiring | **Behavioral change** — previously fell through to `UnsupportedWebhookReceived`. Now enriched via `GetOrder`, stored, and dispatched. Needed test coverage + docs. |
| `Store*Data::$metadata`, `OrderPaid::$metadata` (alpha.3) | Additive. Driver never did the redundant `GetOrder` this removed, and doesn't surface metadata. No change. |
| `OrderWriter::store(): ?OrderInterface` nullable (alpha.3) | Driver's non-nullable returns are covariant-compatible. No change. |
| `UpdateSubscriptionData::$status` (alpha.3) | Driver derives subscription state from dates (no `status` column). Intentionally ignored. No change. |
| `cancelledAt` → `canceledAt` rename (alpha.4) | Internal to fluent; public `isCancelled()` unchanged. No change. |

Most changes are additive (hence the suite stayed green), but `payment.failed` routing was a previously-untested path now reaching the Eloquent order repo.

## Changes

- **composer.json** — floor `^0.8.0-alpha.1` → `^0.8.0-alpha.4`.
- **tests/Http/Controllers/VatlyInboundWebhookControllerTest.php** — two new tests: `payment.failed` stores the order (upstream status mirrored verbatim, not a synthetic `'failed'`) and dispatches `PaymentFailed`.
- **docs/Webhooks.md** — corrected sections that were stale since the v0.7/v0.8 refactor:
  - "Built-in listeners" → "Built-in reactions": the named Laravel listener classes (`StartSubscriptionListener`, etc.) no longer exist; replaced with fluent's reactions wired via `WebhookProcessorFactory`.
  - "Custom listeners": fixed namespace (`Vatly\Laravel\Events` → `Vatly\Fluent\Events`) and corrected the event property accessors to match the real constructors.
  - Events table: removed the never-dispatched `WebhookReceived` row (internal DTO); added `UnsupportedWebhookReceived`, `LocalSubscriptionCreated`, `OrderPaid`, `PaymentFailed`.
- **README.md** — dropped never-dispatched `WebhookReceived` from the events list; added `PaymentFailed`.

## Reviewer notes

- The `StoreOrderOnPaymentFailed` reaction persists the **upstream order status verbatim** (typically `pending` during dunning), not a synthesized `'failed'` — the tests assert this. The existing `vatly_orders.status` string column handles it with no migration.
- Order metadata persistence is intentionally **not** added (out of scope; additive upstream feature).
- No `composer.lock` is committed (library repo), so the only resolution change is the one composer.json line.

## Verification

- PHPUnit: **56 tests, 147 assertions** pass (was 54).
- PHPStan: clean. Pint: passing.
