### PR TITLE
chore(deps): bump vatly-fluent-php to ^0.8.0-alpha.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "illuminate/http": "^12.0|^13.0",
         "illuminate/routing": "^12.0|^13.0",
         "illuminate/support": "^12.0|^13.0",
-        "vatly/vatly-fluent-php": "^0.8.0-alpha.4"
+        "vatly/vatly-fluent-php": "^0.8.0-alpha.5"
     },
     "require-dev": {
         "larastan/larastan": "^3.9",


### PR DESCRIPTION
Adopts `vatly/vatly-fluent-php` **v0.8.0-alpha.5**, which pulls in the latest `vatly/vatly-api-php` **v0.1.0-alpha.11** (recognizes the `webhook.setup` verification event).

Dependency bump only — no driver source changes required.

## Verification
- `composer test` → 56 tests, 147 assertions, all passing
- `composer analyse` (PHPStan) → no errors
