### PR TITLE
Persist Subscription mandate locally — schema + getters + repo writes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "illuminate/http": "^12.0|^13.0",
         "illuminate/routing": "^12.0|^13.0",
         "illuminate/support": "^12.0|^13.0",
-        "vatly/vatly-fluent-php": "^0.8.0-alpha.4"
+        "vatly/vatly-fluent-php": "dev-feat/persist-mandate-locally as 0.8.0-alpha.5"
     },
     "require-dev": {
         "larastan/larastan": "^3.9",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "illuminate/http": "^12.0|^13.0",
         "illuminate/routing": "^12.0|^13.0",
         "illuminate/support": "^12.0|^13.0",
-        "vatly/vatly-fluent-php": "dev-feat/persist-mandate-locally as 0.8.0-alpha.6"
+        "vatly/vatly-fluent-php": "^0.8.0-alpha.6"
     },
     "require-dev": {
         "larastan/larastan": "^3.9",

--- a/database/migrations/create_vatly_subscriptions_table.php.stub
+++ b/database/migrations/create_vatly_subscriptions_table.php.stub
@@ -21,6 +21,10 @@ return new class extends Migration
             $table->integer('quantity')->nullable();
             $table->timestamp('ends_at')->nullable();
             $table->string('customer_id')->nullable()->index();
+            // Mandate summary from Vatly\API\Types\Mandate — persisted so portal
+            // renders avoid a per-request GetSubscription roundtrip.
+            $table->string('mandate_method')->nullable();
+            $table->string('mandate_masked_identifier')->nullable();
             $table->timestamps();
         });
     }

--- a/src/Models/Subscription.php
+++ b/src/Models/Subscription.php
@@ -31,6 +31,8 @@ use Vatly\Fluent\Vatly;
  * @property string $name
  * @property int $quantity
  * @property string|null $customer_id The Vatly customer id (cus_…), populated even for anonymous flows.
+ * @property string|null $mandate_method Normalized payment method category (card, sepa_debit, paypal, bacs_debit).
+ * @property string|null $mandate_masked_identifier Customer-facing identifier — card last 4, masked IBAN, etc.
  * @property Carbon|null $trial_ends_at
  * @property Carbon|null $ends_at
  *
@@ -90,6 +92,16 @@ class Subscription extends Model implements SubscriptionInterface
     public function getEndsAt(): ?DateTimeInterface
     {
         return $this->ends_at;
+    }
+
+    public function getMandateMethod(): ?string
+    {
+        return $this->mandate_method;
+    }
+
+    public function getMandateMaskedIdentifier(): ?string
+    {
+        return $this->mandate_masked_identifier;
     }
 
     // --- Predicate aliases (active / canceled / onGracePeriod / valid / recurring / ended) ---

--- a/src/Repositories/EloquentSubscriptionRepository.php
+++ b/src/Repositories/EloquentSubscriptionRepository.php
@@ -34,6 +34,8 @@ class EloquentSubscriptionRepository implements SubscriptionRepositoryInterface
             'plan_id' => $data->planId,
             'name' => $data->name,
             'quantity' => $data->quantity,
+            'mandate_method' => $data->mandateMethod,
+            'mandate_masked_identifier' => $data->mandateMaskedIdentifier,
         ];
 
         if ($data->hostCustomerId !== null) {
@@ -61,6 +63,12 @@ class EloquentSubscriptionRepository implements SubscriptionRepositoryInterface
                 $subscription->ends_at = Carbon::instance($data->endsAt);
             } elseif ($data->clearEndsAt) {
                 $subscription->ends_at = null;
+            }
+            if ($data->mandateMethod !== null) {
+                $subscription->mandate_method = $data->mandateMethod;
+            }
+            if ($data->mandateMaskedIdentifier !== null) {
+                $subscription->mandate_masked_identifier = $data->mandateMaskedIdentifier;
             }
             $subscription->save();
         }

--- a/src/Repositories/EloquentSubscriptionRepository.php
+++ b/src/Repositories/EloquentSubscriptionRepository.php
@@ -66,9 +66,13 @@ class EloquentSubscriptionRepository implements SubscriptionRepositoryInterface
             }
             if ($data->mandateMethod !== null) {
                 $subscription->mandate_method = $data->mandateMethod;
+            } elseif ($data->clearMandate) {
+                $subscription->mandate_method = null;
             }
             if ($data->mandateMaskedIdentifier !== null) {
                 $subscription->mandate_masked_identifier = $data->mandateMaskedIdentifier;
+            } elseif ($data->clearMandate) {
+                $subscription->mandate_masked_identifier = null;
             }
             $subscription->save();
         }

--- a/src/Repositories/EloquentSubscriptionRepository.php
+++ b/src/Repositories/EloquentSubscriptionRepository.php
@@ -34,8 +34,8 @@ class EloquentSubscriptionRepository implements SubscriptionRepositoryInterface
             'plan_id' => $data->planId,
             'name' => $data->name,
             'quantity' => $data->quantity,
-            'mandate_method' => $data->mandateMethod,
-            'mandate_masked_identifier' => $data->mandateMaskedIdentifier,
+            'mandate_method' => $data->mandate?->method,
+            'mandate_masked_identifier' => $data->mandate?->maskedIdentifier,
         ];
 
         if ($data->hostCustomerId !== null) {
@@ -64,14 +64,16 @@ class EloquentSubscriptionRepository implements SubscriptionRepositoryInterface
             } elseif ($data->clearEndsAt) {
                 $subscription->ends_at = null;
             }
-            if ($data->mandateMethod !== null) {
-                $subscription->mandate_method = $data->mandateMethod;
+            // Mandate is an atomic value object: a non-null Mandate replaces
+            // both columns in one write (preventing mixed local state like
+            // "paypal / 4242" when switching from a card mandate to a paypal
+            // mandate that has no identifier). clearMandate explicitly nulls
+            // both. Null Mandate with clearMandate=false is no-op.
+            if ($data->mandate !== null) {
+                $subscription->mandate_method = $data->mandate->method;
+                $subscription->mandate_masked_identifier = $data->mandate->maskedIdentifier;
             } elseif ($data->clearMandate) {
                 $subscription->mandate_method = null;
-            }
-            if ($data->mandateMaskedIdentifier !== null) {
-                $subscription->mandate_masked_identifier = $data->mandateMaskedIdentifier;
-            } elseif ($data->clearMandate) {
                 $subscription->mandate_masked_identifier = null;
             }
             $subscription->save();

--- a/tests/Feature/AnonymousCheckoutFlowTest.php
+++ b/tests/Feature/AnonymousCheckoutFlowTest.php
@@ -65,6 +65,14 @@ class AnonymousCheckoutFlowTest extends BaseTestCase
 
         $this->assertDatabaseMissing('users', ['vatly_id' => $anonymousCustomerId]);
 
+        $this->fakeGetSubscription($this->buildApiSubscription([
+            'id' => 'sub_anon_1',
+            'customerId' => $anonymousCustomerId,
+            'subscriptionPlanId' => 'plan_basic',
+            'name' => 'Basic',
+            'quantity' => 1,
+        ]));
+
         $this->postWebhookEvent('subscription.started', 'sub_anon_1', 'subscription', [
             'customerId' => $anonymousCustomerId,
             'subscriptionPlanId' => 'plan_basic',
@@ -137,6 +145,23 @@ class AnonymousCheckoutFlowTest extends BaseTestCase
     public function test_claim_does_not_touch_purchases_belonging_to_a_different_anonymous_customer(): void
     {
         // Two distinct anonymous customers each made a purchase.
+        $this->fakeGetSubscriptions([
+            'sub_alice' => $this->buildApiSubscription([
+                'id' => 'sub_alice',
+                'customerId' => 'cus_alice',
+                'subscriptionPlanId' => 'plan_basic',
+                'name' => 'Basic',
+                'quantity' => 1,
+            ]),
+            'sub_bob' => $this->buildApiSubscription([
+                'id' => 'sub_bob',
+                'customerId' => 'cus_bob',
+                'subscriptionPlanId' => 'plan_basic',
+                'name' => 'Basic',
+                'quantity' => 1,
+            ]),
+        ]);
+
         $this->postWebhookEvent('subscription.started', 'sub_alice', 'subscription', [
             'customerId' => 'cus_alice',
             'subscriptionPlanId' => 'plan_basic',
@@ -183,6 +208,14 @@ class AnonymousCheckoutFlowTest extends BaseTestCase
             'taxRates' => [
                 ['name' => 'VAT', 'percentage' => 21.0, 'taxablePercentage' => 100.0, 'amount' => '3.30'],
             ],
+        ]));
+
+        $this->fakeGetSubscription($this->buildApiSubscription([
+            'id' => 'sub_first',
+            'customerId' => 'cus_charlie',
+            'subscriptionPlanId' => 'plan_basic',
+            'name' => 'Basic',
+            'quantity' => 1,
         ]));
 
         // Anonymous purchase lands first.

--- a/tests/Fixtures/migrations/2024_01_01_000002_create_vatly_tables.php
+++ b/tests/Fixtures/migrations/2024_01_01_000002_create_vatly_tables.php
@@ -19,6 +19,8 @@ return new class extends Migration
             $table->timestamp('trial_ends_at')->nullable();
             $table->timestamp('ends_at')->nullable();
             $table->string('customer_id')->nullable()->index();
+            $table->string('mandate_method')->nullable();
+            $table->string('mandate_masked_identifier')->nullable();
             $table->timestamps();
         });
 

--- a/tests/Http/Controllers/VatlyInboundWebhookControllerTest.php
+++ b/tests/Http/Controllers/VatlyInboundWebhookControllerTest.php
@@ -7,6 +7,7 @@ namespace Vatly\Laravel\Tests\Http\Controllers;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Event;
+use Vatly\API\Types\Mandate;
 use Vatly\Fluent\Events\PaymentFailed;
 use Vatly\Laravel\Models\Order;
 use Vatly\Laravel\Models\Subscription;
@@ -28,6 +29,14 @@ class VatlyInboundWebhookControllerTest extends BaseTestCase
     public function test_it_returns_201_for_a_valid_signed_webhook(): void
     {
         User::factory()->create(['vatly_id' => 'customer_foo']);
+
+        $this->fakeGetSubscription($this->buildApiSubscription([
+            'id' => 'sub_123',
+            'customerId' => 'customer_foo',
+            'subscriptionPlanId' => 'plan_foo',
+            'name' => 'Test Plan',
+            'quantity' => 1,
+        ]));
 
         $response = $this->postWebhookEvent('subscription.started', 'sub_123', 'subscription', [
             'customerId' => 'customer_foo',
@@ -98,6 +107,15 @@ class VatlyInboundWebhookControllerTest extends BaseTestCase
     {
         $user = User::factory()->create(['vatly_id' => 'customer_abc']);
 
+        $this->fakeGetSubscription($this->buildApiSubscription([
+            'id' => 'sub_999',
+            'customerId' => 'customer_abc',
+            'subscriptionPlanId' => 'plan_premium',
+            'name' => 'Premium Plan',
+            'quantity' => 1,
+            'mandate' => new Mandate('card', '4242'),
+        ]));
+
         $response = $this->postWebhookEvent('subscription.started', 'sub_999', 'subscription', [
             'customerId' => 'customer_abc',
             'subscriptionPlanId' => 'plan_premium',
@@ -111,6 +129,8 @@ class VatlyInboundWebhookControllerTest extends BaseTestCase
             'plan_id' => 'plan_premium',
             'name' => 'Premium Plan',
             'owner_id' => $user->id,
+            'mandate_method' => 'card',
+            'mandate_masked_identifier' => '4242',
         ]);
     }
 

--- a/tests/Repositories/EloquentSubscriptionRepositoryTest.php
+++ b/tests/Repositories/EloquentSubscriptionRepositoryTest.php
@@ -164,6 +164,42 @@ class EloquentSubscriptionRepositoryTest extends BaseTestCase
         $this->assertSame('plan_premium', $fresh->plan_id);
     }
 
+    public function test_update_with_clear_mandate_nulls_both_columns(): void
+    {
+        $subscription = $this->makeSubscription([
+            'mandate_method' => 'card',
+            'mandate_masked_identifier' => '4242',
+        ]);
+
+        $this->repo->update($subscription, new UpdateSubscriptionData(
+            clearMandate: true,
+        ));
+
+        $fresh = $subscription->fresh();
+        $this->assertNull($fresh->mandate_method);
+        $this->assertNull($fresh->mandate_masked_identifier);
+    }
+
+    public function test_update_with_clear_mandate_and_replacement_values_keeps_replacement(): void
+    {
+        // Matches the existing endsAt precedence: a non-null replacement
+        // wins over the clear flag.
+        $subscription = $this->makeSubscription([
+            'mandate_method' => 'card',
+            'mandate_masked_identifier' => '4242',
+        ]);
+
+        $this->repo->update($subscription, new UpdateSubscriptionData(
+            mandateMethod: 'sepa_debit',
+            mandateMaskedIdentifier: 'NL91****4300',
+            clearMandate: true,
+        ));
+
+        $fresh = $subscription->fresh();
+        $this->assertSame('sepa_debit', $fresh->mandate_method);
+        $this->assertSame('NL91****4300', $fresh->mandate_masked_identifier);
+    }
+
     /**
      * @param  array<string, mixed>  $overrides
      */

--- a/tests/Repositories/EloquentSubscriptionRepositoryTest.php
+++ b/tests/Repositories/EloquentSubscriptionRepositoryTest.php
@@ -6,6 +6,7 @@ namespace Vatly\Laravel\Tests\Repositories;
 
 use Carbon\CarbonImmutable;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Vatly\Fluent\Data\StoreSubscriptionData;
 use Vatly\Fluent\Data\UpdateSubscriptionData;
 use Vatly\Laravel\Models\Subscription;
 use Vatly\Laravel\Repositories\EloquentSubscriptionRepository;
@@ -90,6 +91,77 @@ class EloquentSubscriptionRepositoryTest extends BaseTestCase
             $subscription->fresh()->ends_at->format('Y-m-d H:i:s'),
         );
         $this->assertSame('plan_premium', $subscription->fresh()->plan_id);
+    }
+
+    public function test_store_persists_mandate_fields_when_present(): void
+    {
+        $stored = $this->repo->store(new StoreSubscriptionData(
+            vatlyId: 'subscription_with_mandate',
+            customerId: 'cus_xyz',
+            type: 'default',
+            planId: 'plan_basic',
+            name: 'Basic',
+            quantity: 1,
+            mandateMethod: 'card',
+            mandateMaskedIdentifier: '4242',
+        ));
+
+        $this->assertSame('card', $stored->getMandateMethod());
+        $this->assertSame('4242', $stored->getMandateMaskedIdentifier());
+        $this->assertDatabaseHas('vatly_subscriptions', [
+            'vatly_id' => 'subscription_with_mandate',
+            'mandate_method' => 'card',
+            'mandate_masked_identifier' => '4242',
+        ]);
+    }
+
+    public function test_store_leaves_mandate_null_when_not_supplied(): void
+    {
+        $stored = $this->repo->store(new StoreSubscriptionData(
+            vatlyId: 'subscription_no_mandate',
+            customerId: 'cus_xyz',
+            type: 'default',
+            planId: 'plan_basic',
+            name: 'Basic',
+            quantity: 1,
+        ));
+
+        $this->assertNull($stored->getMandateMethod());
+        $this->assertNull($stored->getMandateMaskedIdentifier());
+    }
+
+    public function test_update_writes_mandate_fields_when_present(): void
+    {
+        $subscription = $this->makeSubscription([
+            'mandate_method' => 'card',
+            'mandate_masked_identifier' => '4242',
+        ]);
+
+        $this->repo->update($subscription, new UpdateSubscriptionData(
+            mandateMethod: 'sepa_debit',
+            mandateMaskedIdentifier: 'NL91****4300',
+        ));
+
+        $fresh = $subscription->fresh();
+        $this->assertSame('sepa_debit', $fresh->mandate_method);
+        $this->assertSame('NL91****4300', $fresh->mandate_masked_identifier);
+    }
+
+    public function test_update_leaves_existing_mandate_alone_when_data_is_null(): void
+    {
+        $subscription = $this->makeSubscription([
+            'mandate_method' => 'card',
+            'mandate_masked_identifier' => '4242',
+        ]);
+
+        $this->repo->update($subscription, new UpdateSubscriptionData(
+            planId: 'plan_premium',
+        ));
+
+        $fresh = $subscription->fresh();
+        $this->assertSame('card', $fresh->mandate_method);
+        $this->assertSame('4242', $fresh->mandate_masked_identifier);
+        $this->assertSame('plan_premium', $fresh->plan_id);
     }
 
     /**

--- a/tests/Repositories/EloquentSubscriptionRepositoryTest.php
+++ b/tests/Repositories/EloquentSubscriptionRepositoryTest.php
@@ -6,6 +6,7 @@ namespace Vatly\Laravel\Tests\Repositories;
 
 use Carbon\CarbonImmutable;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Vatly\API\Types\Mandate;
 use Vatly\Fluent\Data\StoreSubscriptionData;
 use Vatly\Fluent\Data\UpdateSubscriptionData;
 use Vatly\Laravel\Models\Subscription;
@@ -102,8 +103,7 @@ class EloquentSubscriptionRepositoryTest extends BaseTestCase
             planId: 'plan_basic',
             name: 'Basic',
             quantity: 1,
-            mandateMethod: 'card',
-            mandateMaskedIdentifier: '4242',
+            mandate: new Mandate('card', '4242'),
         ));
 
         $this->assertSame('card', $stored->getMandateMethod());
@@ -138,13 +138,32 @@ class EloquentSubscriptionRepositoryTest extends BaseTestCase
         ]);
 
         $this->repo->update($subscription, new UpdateSubscriptionData(
-            mandateMethod: 'sepa_debit',
-            mandateMaskedIdentifier: 'NL91****4300',
+            mandate: new Mandate('sepa_debit', 'NL91****4300'),
         ));
 
         $fresh = $subscription->fresh();
         $this->assertSame('sepa_debit', $fresh->mandate_method);
         $this->assertSame('NL91****4300', $fresh->mandate_masked_identifier);
+    }
+
+    public function test_update_atomically_replaces_card_with_paypal_clearing_stale_last4(): void
+    {
+        // Regression: switching to a mandate type without an identifier
+        // (paypal) used to leave the old card's last4 stored alongside
+        // method='paypal'. Now the Mandate object is atomic, so both
+        // columns get rewritten together.
+        $subscription = $this->makeSubscription([
+            'mandate_method' => 'card',
+            'mandate_masked_identifier' => '4242',
+        ]);
+
+        $this->repo->update($subscription, new UpdateSubscriptionData(
+            mandate: new Mandate('paypal', null),
+        ));
+
+        $fresh = $subscription->fresh();
+        $this->assertSame('paypal', $fresh->mandate_method);
+        $this->assertNull($fresh->mandate_masked_identifier);
     }
 
     public function test_update_leaves_existing_mandate_alone_when_data_is_null(): void
@@ -190,8 +209,7 @@ class EloquentSubscriptionRepositoryTest extends BaseTestCase
         ]);
 
         $this->repo->update($subscription, new UpdateSubscriptionData(
-            mandateMethod: 'sepa_debit',
-            mandateMaskedIdentifier: 'NL91****4300',
+            mandate: new Mandate('sepa_debit', 'NL91****4300'),
             clearMandate: true,
         ));
 

--- a/tests/TestHelpers/PostsVatlyWebhooks.php
+++ b/tests/TestHelpers/PostsVatlyWebhooks.php
@@ -8,10 +8,13 @@ use Illuminate\Testing\TestResponse;
 use Mockery;
 use ReflectionClass;
 use Vatly\API\Resources\Order as ApiOrder;
+use Vatly\API\Resources\Subscription as ApiSubscription;
+use Vatly\API\Types\Mandate;
 use Vatly\API\Types\Money;
 use Vatly\API\Types\TaxSummaryCollection;
 use Vatly\API\VatlyApiClient;
 use Vatly\Fluent\Actions\GetOrder;
+use Vatly\Fluent\Actions\GetSubscription;
 use Vatly\Fluent\Vatly;
 use Vatly\Fluent\Webhooks\WebhookProcessor;
 
@@ -98,6 +101,78 @@ trait PostsVatlyWebhooks
         $this->writeVatlyPrivate($vatly, 'webhookProcessor', null);
 
         $this->app->forgetInstance(WebhookProcessor::class);
+    }
+
+    /**
+     * Replace the cached `GetSubscription` action on the composition root
+     * so the `subscription.started` webhook flow doesn't need a real API
+     * call. WebhookEventFactory enriches the event via this action to pull
+     * the mandate summary into the dispatched event.
+     *
+     * Returns the same subscription regardless of which Vatly id is asked
+     * for. For tests that need different subscriptions per id, use
+     * {@see self::fakeGetSubscriptions()}.
+     */
+    protected function fakeGetSubscription(ApiSubscription $subscription): void
+    {
+        $this->fakeGetSubscriptions([
+            $subscription->id => $subscription,
+        ], strict: false);
+    }
+
+    /**
+     * Replace the cached `GetSubscription` action with a fake that returns
+     * a different `ApiSubscription` per Vatly subscription id.
+     *
+     * @param  array<string, ApiSubscription>  $subscriptions  keyed by Vatly subscription id
+     * @param  bool  $strict  when true, asking for an id not in the map throws.
+     */
+    protected function fakeGetSubscriptions(array $subscriptions, bool $strict = true): void
+    {
+        $action = Mockery::mock(GetSubscription::class);
+        $action->shouldReceive('execute')->andReturnUsing(function (string $id) use ($subscriptions, $strict) {
+            if (isset($subscriptions[$id])) {
+                return $subscriptions[$id];
+            }
+            if ($strict) {
+                throw new \RuntimeException("No fake ApiSubscription registered for id '{$id}'.");
+            }
+
+            return reset($subscriptions);
+        });
+
+        $vatly = $this->app->make(Vatly::class);
+
+        $this->writeVatlyPrivate($vatly, 'getSubscription', $action);
+        $this->writeVatlyPrivate($vatly, 'webhookEventFactory', null);
+        $this->writeVatlyPrivate($vatly, 'webhookProcessor', null);
+
+        $this->app->forgetInstance(WebhookProcessor::class);
+    }
+
+    /**
+     * Build a minimal ApiSubscription for `fakeGetSubscription()` callers.
+     *
+     * @param  array{
+     *   id: string,
+     *   customerId: ?string,
+     *   subscriptionPlanId: string,
+     *   name: string,
+     *   quantity: int,
+     *   mandate?: ?Mandate,
+     * }  $data
+     */
+    protected function buildApiSubscription(array $data): ApiSubscription
+    {
+        $subscription = new ApiSubscription(Mockery::mock(VatlyApiClient::class));
+        $subscription->id = $data['id'];
+        $subscription->customerId = $data['customerId'] ?? null;
+        $subscription->subscriptionPlanId = $data['subscriptionPlanId'];
+        $subscription->name = $data['name'];
+        $subscription->quantity = $data['quantity'];
+        $subscription->mandate = $data['mandate'] ?? null;
+
+        return $subscription;
     }
 
     private function writeVatlyPrivate(object $target, string $property, mixed $value): void


### PR DESCRIPTION
## Summary

Driver-side companion to [vatly/vatly-fluent-php#56](https://github.com/vatly/vatly-fluent-php/pull/56). That PR adds `getMandateMethod()` / `getMandateMaskedIdentifier()` to `SubscriptionInterface` and plumbs them through `StoreSubscriptionData`, `UpdateSubscriptionData`, and the `SyncSubscriptionOnStarted` reaction. This PR implements the host-side persistence so the Eloquent `Subscription` model actually stores them.

After both PRs land, consumers building billing portals (e.g. [sandervanhooft/larafast-vatly](https://github.com/sandervanhooft/larafast-vatly)) read `$subscription->getMandateMethod()` / `$subscription->getMandateMaskedIdentifier()` directly — no per-render API roundtrip.

## What changed

### Migration

`vatly_subscriptions` gains:

```php
$table->string('mandate_method')->nullable();           // 'card' / 'sepa_debit' / 'paypal' / 'bacs_debit'
$table->string('mandate_masked_identifier')->nullable(); // '4242' / 'NL91****4300' / null
```

### `Models\Subscription`

Implements the two new `SubscriptionInterface` getters:

```php
public function getMandateMethod(): ?string         { return $this->mandate_method; }
public function getMandateMaskedIdentifier(): ?string { return $this->mandate_masked_identifier; }
```

Plus updated `@property` docblocks.

### `EloquentSubscriptionRepository`

`store()` persists both fields from `StoreSubscriptionData`. `update()` writes them when non-null in `UpdateSubscriptionData` (null = "no change", consistent with the other update fields). To clear mandate explicitly, drivers should add a `clearMandate` flag later if the use case appears — Vatly doesn't currently emit mandate-removal events.

### `PostsVatlyWebhooks` test helper

`subscription.started` webhook flows now hit fluent's `GetSubscription` enrichment path. Tests that exercise that flow need to stub the API call. Added:

- `fakeGetSubscription(ApiSubscription)` — single-subscription convenience, mirrors `fakeGetOrder()`
- `fakeGetSubscriptions(array $map)` — map-keyed by Vatly subscription id, for tests that post multiple `subscription.started` events
- `buildApiSubscription(array)` — builds the API resource for the fake

## Upgrade steps for existing merchants

1. Bump `vatly/vatly-laravel` constraint
2. `php artisan vendor:publish --tag=vatly-migrations --force` then `migrate`
3. Mandates backfill lazily — on first `$user->subscription()->sync()`, or eagerly via a one-off `Subscription::each(fn (\$s) => \$s->sync())` if you want all rows populated immediately

## Tests

60 tests / 157 assertions pass. New coverage:

- `EloquentSubscriptionRepositoryTest::test_store_persists_mandate_fields_when_present`
- `EloquentSubscriptionRepositoryTest::test_store_leaves_mandate_null_when_not_supplied`
- `EloquentSubscriptionRepositoryTest::test_update_writes_mandate_fields_when_present`
- `EloquentSubscriptionRepositoryTest::test_update_leaves_existing_mandate_alone_when_data_is_null`
- `VatlyInboundWebhookControllerTest::test_it_creates_a_subscription_from_webhook` asserts the mandate columns get populated end-to-end when the webhook delivers and the API returns a Mandate

## Dependency note

Pinned to `vatly/vatly-fluent-php: dev-feat/persist-mandate-locally as 0.8.0-alpha.5` during PR review. Once vatly/vatly-fluent-php#56 merges and ships as `v0.9.0-alpha.1`, will swap the constraint to `^0.9.0-alpha.1` in a follow-up commit.

## Suggested release

`v0.8.0-alpha.1` once fluent ships v0.9.0-alpha.1.