### PR TITLE
feat: adopt vatly-fluent-php alpha.8 — refund persistence + new webhook events

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Pin to an exact version during alpha — the API will change.
    php artisan migrate
    ```
 
-   This adds a `vatly_id` column to your users table plus `vatly_subscriptions`, `vatly_orders`, and `vatly_webhook_calls` tables.
+   This adds a `vatly_id` column to your users table plus `vatly_subscriptions`, `vatly_orders`, `vatly_refunds`, and `vatly_webhook_calls` tables.
 
 4. **Add the `Billable` trait to your User model:**
 
@@ -140,12 +140,19 @@ Event::listen(OrderPaid::class, function (OrderPaid $event) {
 Events available:
 
 - `Vatly\Fluent\Events\OrderPaid` — carries `total`, `subtotal`, `taxSummary` (full per-rate breakdown), `currency`, `invoiceNumber`, `paymentMethod`. Materialize local invoices without an extra API call.
+- `Vatly\Fluent\Events\OrderCanceled` — the local order's status is mirrored to `canceled`.
+- `Vatly\Fluent\Events\OrderChargebackReceived` / `OrderChargebackReversed` — dispute signals carrying the affected `orderId` (no local row is mutated; react to suspend/reinstate access).
 - `Vatly\Fluent\Events\PaymentFailed` — same enriched order shape as `OrderPaid`; typically the start of dunning.
+- `Vatly\Fluent\Events\RefundCompleted` / `RefundFailed` / `RefundCanceled` — each with full `taxSummary`; persisted to `vatly_refunds` (see below).
 - `Vatly\Fluent\Events\SubscriptionStarted`
+- `Vatly\Fluent\Events\SubscriptionBillingUpdated` — the stored mandate (`mandate_method` / `mandate_masked_identifier`) is refreshed.
+- `Vatly\Fluent\Events\SubscriptionResumed` — the stored end date is cleared.
 - `Vatly\Fluent\Events\SubscriptionCanceledImmediately`
 - `Vatly\Fluent\Events\SubscriptionCanceledWithGracePeriod`
 - `Vatly\Fluent\Events\LocalSubscriptionCreated`
 - `Vatly\Fluent\Events\UnsupportedWebhookReceived`
+
+Refund webhooks (`refund.completed` / `refund.failed` / `refund.canceled`) are persisted to the `vatly_refunds` table via the bundled `Refund` model and `EloquentRefundRepository`. Chargeback events ship no built-in persistence — Vatly's public order status doesn't change on a chargeback, so wire your own listener if you need to suspend/reinstate access.
 
 The webhook route is named `vatly.webhook` — reach it with `route('vatly.webhook')`.
 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "illuminate/http": "^12.0|^13.0",
         "illuminate/routing": "^12.0|^13.0",
         "illuminate/support": "^12.0|^13.0",
-        "vatly/vatly-fluent-php": "^0.8.0-alpha.6"
+        "vatly/vatly-fluent-php": "^0.8.0-alpha.8"
     },
     "require-dev": {
         "larastan/larastan": "^3.9",

--- a/database/migrations/create_vatly_refunds_table.php.stub
+++ b/database/migrations/create_vatly_refunds_table.php.stub
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('vatly_refunds', function (Blueprint $table) {
+            $table->id();
+            $table->nullableMorphs('owner');
+            $table->string('vatly_id')->unique();
+            $table->string('original_order_id')->index();
+            $table->string('status');
+            $table->integer('total');
+            $table->integer('subtotal')->nullable();
+            $table->json('tax_summary')->nullable();
+            $table->string('currency', 3);
+            $table->string('customer_id')->nullable()->index();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('vatly_refunds');
+    }
+};

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -36,6 +36,9 @@ parameters:
         -
             message: '#^Method Vatly\\Laravel\\Models\\Subscription::owner\(\) should return Illuminate\\Database\\Eloquent\\Relations\\MorphTo.+ but returns .+\.$#'
             path: src/Models/Subscription.php
+        -
+            message: '#^Method Vatly\\Laravel\\Models\\Refund::owner\(\) should return Illuminate\\Database\\Eloquent\\Relations\\MorphTo.+ but returns .+\.$#'
+            path: src/Models/Refund.php
 
         # Model uses Billable trait which adds vatlyId() method
         -

--- a/src/Models/Refund.php
+++ b/src/Models/Refund.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Laravel\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Vatly\Fluent\Contracts\RefundInterface;
+
+/**
+ * @property string $vatly_id
+ * @property string|null $owner_type
+ * @property int|null $owner_id
+ * @property string|null $customer_id The Vatly customer id (cus_…).
+ * @property string $original_order_id The Vatly id of the order the refund was issued against.
+ * @property string $status
+ * @property int $total
+ * @property int|null $subtotal
+ * @property array<int, array{rate: array{name: string, percentage: float, taxablePercentage: float}, amount: int, currency: string}>|null $tax_summary
+ * @property string $currency
+ *
+ * @method static create(array<string, mixed> $array)
+ * @method static where(string $column, mixed $value)
+ */
+class Refund extends Model implements RefundInterface
+{
+    protected $table = 'vatly_refunds';
+
+    protected $guarded = [];
+
+    /**
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'tax_summary' => 'array',
+    ];
+
+    /**
+     * @return MorphTo<Model, Refund>
+     */
+    public function owner(): MorphTo
+    {
+        return $this->morphTo('owner');
+    }
+
+    // RefundInterface implementation
+
+    public function getVatlyId(): string
+    {
+        return $this->vatly_id;
+    }
+
+    public function getStatus(): string
+    {
+        return $this->status;
+    }
+
+    public function getTotal(): int
+    {
+        return (int) $this->total;
+    }
+
+    public function getCurrency(): string
+    {
+        return $this->currency;
+    }
+
+    public function getOriginalOrderId(): string
+    {
+        return $this->original_order_id;
+    }
+
+    public function isCompleted(): bool
+    {
+        return $this->status === 'refunded';
+    }
+}

--- a/src/Repositories/EloquentRefundRepository.php
+++ b/src/Repositories/EloquentRefundRepository.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Laravel\Repositories;
+
+use Vatly\Fluent\Contracts\RefundInterface;
+use Vatly\Fluent\Contracts\RefundRepositoryInterface;
+use Vatly\Fluent\Data\StoreRefundData;
+use Vatly\Fluent\Data\UpdateRefundData;
+use Vatly\Laravel\Models\Refund;
+use Vatly\Laravel\VatlyConfig;
+
+class EloquentRefundRepository implements RefundRepositoryInterface
+{
+    public function __construct(
+        private readonly VatlyConfig $config,
+    ) {
+        //
+    }
+
+    public function findByVatlyId(string $vatlyId): ?RefundInterface
+    {
+        return Refund::where('vatly_id', $vatlyId)->first();
+    }
+
+    public function store(StoreRefundData $data): RefundInterface
+    {
+        $attrs = [
+            'vatly_id' => $data->vatlyId,
+            'customer_id' => $data->customerId,
+            'original_order_id' => $data->originalOrderId,
+            'status' => $data->status,
+            'total' => $data->total,
+            'subtotal' => $data->subtotal,
+            'tax_summary' => $data->taxSummary?->toArray(),
+            'currency' => $data->currency,
+        ];
+
+        if ($data->hostCustomerId !== null) {
+            $model = $this->config->getBillableModel();
+            $attrs['owner_type'] = (new $model)->getMorphClass();
+            $attrs['owner_id'] = $data->hostCustomerId;
+        }
+
+        return Refund::create($attrs);
+    }
+
+    public function update(RefundInterface $refund, UpdateRefundData $data): RefundInterface
+    {
+        if ($refund instanceof Refund) {
+            if ($data->status !== null) {
+                $refund->status = $data->status;
+            }
+            if ($data->total !== null) {
+                $refund->total = $data->total;
+            }
+            if ($data->subtotal !== null) {
+                $refund->subtotal = $data->subtotal;
+            }
+            if ($data->taxSummary !== null) {
+                $refund->tax_summary = $data->taxSummary->toArray();
+            }
+            if ($data->currency !== null) {
+                $refund->currency = $data->currency;
+            }
+            $refund->save();
+        }
+
+        return $refund;
+    }
+}

--- a/src/VatlyServiceProvider.php
+++ b/src/VatlyServiceProvider.php
@@ -9,6 +9,7 @@ use Vatly\Fluent\Contracts\ConfigurationInterface;
 use Vatly\Fluent\Contracts\CustomerBindingRepository;
 use Vatly\Fluent\Contracts\EventDispatcherInterface;
 use Vatly\Fluent\Contracts\OrderRepositoryInterface;
+use Vatly\Fluent\Contracts\RefundRepositoryInterface;
 use Vatly\Fluent\Contracts\SubscriptionRepositoryInterface;
 use Vatly\Fluent\Contracts\WebhookCallRepositoryInterface;
 use Vatly\Fluent\Vatly;
@@ -17,6 +18,7 @@ use Vatly\Fluent\Wiring;
 use Vatly\Laravel\Events\LaravelEventDispatcher;
 use Vatly\Laravel\Repositories\EloquentCustomerBindingRepository;
 use Vatly\Laravel\Repositories\EloquentOrderRepository;
+use Vatly\Laravel\Repositories\EloquentRefundRepository;
 use Vatly\Laravel\Repositories\EloquentSubscriptionRepository;
 use Vatly\Laravel\Repositories\EloquentWebhookCallRepository;
 
@@ -31,6 +33,7 @@ class VatlyServiceProvider extends ServiceProvider
         $this->app->bind(ConfigurationInterface::class, VatlyConfig::class);
         $this->app->bind(SubscriptionRepositoryInterface::class, EloquentSubscriptionRepository::class);
         $this->app->bind(OrderRepositoryInterface::class, EloquentOrderRepository::class);
+        $this->app->bind(RefundRepositoryInterface::class, EloquentRefundRepository::class);
         $this->app->bind(WebhookCallRepositoryInterface::class, EloquentWebhookCallRepository::class);
         $this->app->bind(CustomerBindingRepository::class, EloquentCustomerBindingRepository::class);
         $this->app->bind(EventDispatcherInterface::class, LaravelEventDispatcher::class);
@@ -40,6 +43,7 @@ class VatlyServiceProvider extends ServiceProvider
             config: $app->make(ConfigurationInterface::class),
             subscriptions: $app->make(SubscriptionRepositoryInterface::class),
             orders: $app->make(OrderRepositoryInterface::class),
+            refunds: $app->make(RefundRepositoryInterface::class),
             webhookCalls: $app->make(WebhookCallRepositoryInterface::class),
             events: $app->make(EventDispatcherInterface::class),
             customerBindings: $app->make(CustomerBindingRepository::class),
@@ -77,6 +81,7 @@ class VatlyServiceProvider extends ServiceProvider
             __DIR__.'/../database/migrations/create_vatly_subscriptions_table.php.stub' => $this->getMigrationFileName('create_vatly_subscriptions_table.php'),
             __DIR__.'/../database/migrations/create_vatly_webhook_calls_table.php.stub' => $this->getMigrationFileName('create_vatly_webhook_calls_table.php'),
             __DIR__.'/../database/migrations/create_vatly_orders_table.php.stub' => $this->getMigrationFileName('create_vatly_orders_table.php'),
+            __DIR__.'/../database/migrations/create_vatly_refunds_table.php.stub' => $this->getMigrationFileName('create_vatly_refunds_table.php'),
         ], 'vatly-migrations');
     }
 

--- a/tests/Fixtures/migrations/2024_01_01_000002_create_vatly_tables.php
+++ b/tests/Fixtures/migrations/2024_01_01_000002_create_vatly_tables.php
@@ -39,6 +39,20 @@ return new class extends Migration
             $table->timestamps();
         });
 
+        Schema::create('vatly_refunds', function (Blueprint $table) {
+            $table->id();
+            $table->nullableMorphs('owner');
+            $table->string('vatly_id')->unique();
+            $table->string('original_order_id')->index();
+            $table->string('status');
+            $table->integer('total');
+            $table->integer('subtotal')->nullable();
+            $table->json('tax_summary')->nullable();
+            $table->string('currency');
+            $table->string('customer_id')->nullable()->index();
+            $table->timestamps();
+        });
+
         Schema::create('vatly_webhook_calls', function (Blueprint $table) {
             $table->id();
             $table->timestamps();

--- a/tests/Http/Controllers/VatlyInboundWebhookControllerTest.php
+++ b/tests/Http/Controllers/VatlyInboundWebhookControllerTest.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Facades\Event;
 use Vatly\API\Types\Mandate;
 use Vatly\Fluent\Events\PaymentFailed;
 use Vatly\Laravel\Models\Order;
+use Vatly\Laravel\Models\Refund;
 use Vatly\Laravel\Models\Subscription;
 use Vatly\Laravel\Tests\BaseTestCase;
 use Vatly\Laravel\Tests\TestHelpers\PostsVatlyWebhooks;
@@ -292,5 +293,42 @@ class VatlyInboundWebhookControllerTest extends BaseTestCase
         $response->assertStatus(201);
         $subscription = Subscription::where('vatly_id', 'sub_cancel')->first();
         $this->assertTrue($subscription->isCancelled());
+    }
+
+    public function test_it_persists_a_refund_from_webhook(): void
+    {
+        $user = User::factory()->create(['vatly_id' => 'customer_abc']);
+
+        $this->fakeGetRefund($this->buildApiRefund([
+            'id' => 'refund_abc123',
+            'customerId' => 'customer_abc',
+            'originalOrderId' => 'order_abc123',
+            'status' => 'refunded',
+            'totalValue' => '99.00',
+            'subtotalValue' => '81.82',
+            'currency' => 'EUR',
+            'taxRates' => [
+                ['name' => 'VAT', 'percentage' => 21.0, 'taxablePercentage' => 100.0, 'amount' => '17.18'],
+            ],
+        ]));
+
+        $response = $this->postWebhookEvent('refund.completed', 'refund_abc123', 'refund', [
+            'customerId' => 'customer_abc',
+        ]);
+
+        $response->assertStatus(201);
+        $this->assertDatabaseHas('vatly_refunds', [
+            'vatly_id' => 'refund_abc123',
+            'original_order_id' => 'order_abc123',
+            'status' => 'refunded',
+            'total' => 9900,
+            'currency' => 'EUR',
+            'owner_id' => $user->id,
+        ]);
+
+        $refund = Refund::where('vatly_id', 'refund_abc123')->firstOrFail();
+        $this->assertSame(8182, $refund->subtotal);
+        $this->assertSame(1718, $refund->tax_summary[0]['amount']);
+        $this->assertTrue($refund->isCompleted());
     }
 }

--- a/tests/TestHelpers/PostsVatlyWebhooks.php
+++ b/tests/TestHelpers/PostsVatlyWebhooks.php
@@ -8,12 +8,14 @@ use Illuminate\Testing\TestResponse;
 use Mockery;
 use ReflectionClass;
 use Vatly\API\Resources\Order as ApiOrder;
+use Vatly\API\Resources\Refund as ApiRefund;
 use Vatly\API\Resources\Subscription as ApiSubscription;
 use Vatly\API\Types\Mandate;
 use Vatly\API\Types\Money;
 use Vatly\API\Types\TaxSummaryCollection;
 use Vatly\API\VatlyApiClient;
 use Vatly\Fluent\Actions\GetOrder;
+use Vatly\Fluent\Actions\GetRefund;
 use Vatly\Fluent\Actions\GetSubscription;
 use Vatly\Fluent\Vatly;
 use Vatly\Fluent\Webhooks\WebhookProcessor;
@@ -113,6 +115,25 @@ trait PostsVatlyWebhooks
      * for. For tests that need different subscriptions per id, use
      * {@see self::fakeGetSubscriptions()}.
      */
+    /**
+     * Replace the cached `GetRefund` action on the composition root so the
+     * `refund.*` webhook flow doesn't need a real API call. The factory
+     * enriches refund events via this action to carry the full tax breakdown.
+     */
+    protected function fakeGetRefund(ApiRefund $refund): void
+    {
+        $action = Mockery::mock(GetRefund::class);
+        $action->shouldReceive('execute')->andReturn($refund);
+
+        $vatly = $this->app->make(Vatly::class);
+
+        $this->writeVatlyPrivate($vatly, 'getRefund', $action);
+        $this->writeVatlyPrivate($vatly, 'webhookEventFactory', null);
+        $this->writeVatlyPrivate($vatly, 'webhookProcessor', null);
+
+        $this->app->forgetInstance(WebhookProcessor::class);
+    }
+
     protected function fakeGetSubscription(ApiSubscription $subscription): void
     {
         $this->fakeGetSubscriptions([
@@ -217,5 +238,41 @@ trait PostsVatlyWebhooks
         ));
 
         return $order;
+    }
+
+    /**
+     * @param  array{
+     *   id: string,
+     *   customerId: string,
+     *   originalOrderId: string,
+     *   status: string,
+     *   totalValue: string,
+     *   subtotalValue: string,
+     *   currency: string,
+     *   taxRates: array<int, array{name: string, percentage: float, taxablePercentage: float, amount: string}>,
+     * }  $data
+     */
+    protected function buildApiRefund(array $data): ApiRefund
+    {
+        $refund = new ApiRefund(Mockery::mock(VatlyApiClient::class));
+        $refund->id = $data['id'];
+        $refund->customerId = $data['customerId'];
+        $refund->originalOrderId = $data['originalOrderId'];
+        $refund->status = $data['status'];
+        $refund->total = new Money($data['currency'], $data['totalValue']);
+        $refund->subtotal = new Money($data['currency'], $data['subtotalValue']);
+        $refund->taxSummary = new TaxSummaryCollection(array_map(
+            fn (array $rate) => [
+                'taxRate' => [
+                    'name' => $rate['name'],
+                    'percentage' => $rate['percentage'],
+                    'taxablePercentage' => $rate['taxablePercentage'],
+                ],
+                'amount' => ['currency' => $data['currency'], 'value' => $rate['amount']],
+            ],
+            $data['taxRates'],
+        ));
+
+        return $refund;
     }
 }


### PR DESCRIPTION
Adopts `vatly/vatly-fluent-php` **alpha.8** (`^0.8.0-alpha.6` → `^0.8.0-alpha.8`, pulling `vatly-api-php` alpha.12).

## Breaking-change propagation — verified clean
Fluent's alpha.6→alpha.8 reshaped the `Wiring` constructor (new `refunds` param inserted mid-list) and the webhook factory signatures (`WebhookProcessorFactory::create` gained a required `getRefund`; `WebhookEventFactory` a 3rd ctor arg). This package is unaffected because it:
- constructs `Wiring` with **named arguments**, and
- reaches the processor via `Vatly::webhookProcessor()` (never the factories directly).

Confirmed empirically: the **full pre-existing suite passes against alpha.8** with no code changes.

## Adopted: Refund persistence
The one new *persistable* entity. Mirrors the existing Order pattern:
- `Refund` model (`RefundInterface`) + `vatly_refunds` migration (+ `vendor:publish` wiring).
- `EloquentRefundRepository` (`RefundRepositoryInterface`), bound in the service provider and passed to `Wiring(refunds:)`.
- `refund.completed` / `refund.failed` / `refund.canceled` now persist to `vatly_refunds` (store-or-update with full tax breakdown).

The other new fluent events need no new tables: `OrderCanceled` mirrors the existing order's status; `SubscriptionBillingUpdated` / `SubscriptionResumed` update the existing subscription; chargebacks are dispatched for the consumer to handle (Vatly's public order status doesn't change on a chargeback). All documented in the README.

## Tests
Added a `refund.completed` end-to-end webhook test (with `fakeGetRefund` / `buildApiRefund` helpers) asserting persistence + tax breakdown. **64 tests pass; Pint + PHPStan clean.**