### PR TITLE
feat(billable): claimVatlyCustomerFromReturn (anonymous-checkout return matching)

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,16 @@ $checkout = $user->checkout()->create(
     redirectUrlCanceled: 'https://example.com/canceled',
 );
 
+// Guest checkout: put {CHECKOUT_ID} in the return URL — Vatly fills it in,
+// and claimVatlyCustomerFromReturn() links the purchase on the way back.
+$user->checkout()->create(
+    items: [['id' => 'plan_premium', 'quantity' => 1]],
+    redirectUrlSuccess: route('vatly.return').'?checkout_id={CHECKOUT_ID}',
+    redirectUrlCanceled: 'https://example.com/billing',
+);
+// …on the return route (multi-tab safe; no session/cookie plumbing):
+$request->user()->claimVatlyCustomerFromReturn($request);   // see docs/Customers.md
+
 // Subscription state — Cashier-shape predicates
 $user->subscribed();                                    // bool, default type
 $user->subscribed('team');                              // bool, custom type

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "illuminate/http": "^12.0|^13.0",
         "illuminate/routing": "^12.0|^13.0",
         "illuminate/support": "^12.0|^13.0",
-        "vatly/vatly-fluent-php": "^0.8.0-alpha.9"
+        "vatly/vatly-fluent-php": "^0.8.0-alpha.10"
     },
     "require-dev": {
         "larastan/larastan": "^3.9",

--- a/docs/Customers.md
+++ b/docs/Customers.md
@@ -100,6 +100,8 @@ Under the hood `claimVatlyCustomerFromReturn()` resolves the checkout's customer
 2. Saves the model.
 3. Backfills `owner_type` / `owner_id` on every `vatly_subscriptions` and `vatly_orders` row that carries the same `customer_id` but had no owner yet.
 
+The `order.paid` / `subscription.started` webhook usually lands *before* the buyer is redirected back, so those rows already exist (with `owner_id = null`) by the time you claim — step 3 simply backfills them. The reverse order works too: if the claim runs first, it binds the customer, and a later webhook for the same `customer_id` finds the binding and writes `owner_id` directly. Either way the purchase ends up attributed.
+
 If you already hold the `cus_…` by other means, you can still call `claimVatlyCustomer($vatlyCustomerId)` directly; it returns the number of rows re-attributed.
 
 > **Out of scope:** buyers who never come back via the redirect link (closed the tab, switched device). Recovering those is the email-based recovery story — a separate concern this helper does not cover.

--- a/docs/Customers.md
+++ b/docs/Customers.md
@@ -55,25 +55,54 @@ A common flow: a visitor buys *before* they sign up — checkout completes, Vatl
 The package handles this without losing data:
 
 - The `vatly_subscriptions` and `vatly_orders` tables both have a nullable `owner_id`/`owner_type` plus a `customer_id` column. The webhook writes the row with `owner_id = null` but populates `customer_id` with the Vatly customer id (`cus_…`).
-- When the visitor later signs up (or signs in for the first time), call `claimVatlyCustomer($vatlyCustomerId)` on the new `User` to retroactively link the prior rows:
+- When the visitor returns on the checkout-success redirect, call `claimVatlyCustomerFromReturn()` to link those rows to the now-known user.
+
+### Learning the checkout on the redirect back: the `{CHECKOUT_ID}` placeholder
+
+The one hard part of guest checkout is: *how does your app know which Vatly customer to claim when the buyer lands back on your site?* You don't have to plumb the `cus_…` through a session or cookie yourself (that approach breaks under multi-tab / double-click — the last write wins, and the buyer may finish the checkout that *isn't* in the session).
+
+Instead, put the literal `{CHECKOUT_ID}` placeholder in your return URL. Vatly substitutes it with the checkout's id at creation:
 
 ```php
-// In your signup controller — $vatlyCustomerId typically comes from
-// a query param on the checkout-success URL, a session, or a cookie
-// set during the anonymous checkout flow.
-$user = User::create([...]);
-
-$claimed = $user->claimVatlyCustomer($vatlyCustomerId);
-// $claimed is the number of subscription + order rows that were
-// re-attributed to the user. Subsequent $user->orders / $user->subscriptions
-// return them as you'd expect.
+$user->checkout()->create(
+    items: [['id' => 'product_abc123', 'quantity' => 1]],
+    redirectUrlSuccess: route('vatly.return').'?checkout_id={CHECKOUT_ID}',
+    redirectUrlCanceled: route('billing'),
+);
 ```
 
-`claimVatlyCustomer()` does three things:
+On the return route, hand the request to `claimVatlyCustomerFromReturn()`:
+
+```php
+public function return(Request $request)
+{
+    // Reads ?checkout_id=…, resolves that checkout's Vatly customer, and
+    // (if there is one) claims it for the authenticated user.
+    $request->user()->claimVatlyCustomerFromReturn($request);
+
+    return redirect()->route('dashboard');
+}
+```
+
+It returns `true` when a claim happened and `false` for a missing / unknown checkout id or a checkout with no customer yet — so it's safe to call unconditionally. Pass a second argument to read a different query key:
+
+```php
+$user->claimVatlyCustomerFromReturn($request, 'cid'); // reads ?cid=…
+```
+
+This is **multi-tab safe by construction**: each tab carries its own checkout id in its own redirect URL, so two checkouts in flight resolve independently — there is no shared carrier whose last write wins.
+
+> The checkout id travels in the URL, so it may also appear in the `Referer` header and your server logs. It is low-sensitivity — it only names a checkout the buyer just completed — but treat it like any URL parameter.
+
+Under the hood `claimVatlyCustomerFromReturn()` resolves the checkout's customer id via the Vatly API and then runs `claimVatlyCustomer()`, which:
 
 1. Binds the Vatly customer id to this host entity via the configured `CustomerBindingRepository` (default impl: writes `vatly_id` on the billable table).
 2. Saves the model.
 3. Backfills `owner_type` / `owner_id` on every `vatly_subscriptions` and `vatly_orders` row that carries the same `customer_id` but had no owner yet.
+
+If you already hold the `cus_…` by other means, you can still call `claimVatlyCustomer($vatlyCustomerId)` directly; it returns the number of rows re-attributed.
+
+> **Out of scope:** buyers who never come back via the redirect link (closed the tab, switched device). Recovering those is the email-based recovery story — a separate concern this helper does not cover.
 
 Need the email / name on the customer to surface a "would you like to claim purchase X?" prompt at signup? Fetch the customer via the Vatly API:
 

--- a/src/Billable.php
+++ b/src/Billable.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace Vatly\Laravel;
 
 use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Http\Request;
 use Vatly\API\Resources\Customer;
 use Vatly\Fluent\Builders\CheckoutBuilder;
 use Vatly\Fluent\Builders\SubscriptionBuilder;
 use Vatly\Fluent\CustomerProfile;
+use Vatly\Fluent\Exceptions\CustomerAlreadyBoundException;
 use Vatly\Fluent\Exceptions\InvalidOrderException;
 use Vatly\Fluent\OrderHandle;
 use Vatly\Fluent\SubscriptionHandle;
@@ -232,6 +234,48 @@ trait Billable
             ->update($ownerAttrs);
 
         return $subscriptions + $orders;
+    }
+
+    /**
+     * Claim an anonymous Vatly customer on the checkout-success redirect back.
+     *
+     * Reads the checkout id from the request query — Vatly substitutes it into
+     * the redirect URL via the `{CHECKOUT_ID}` placeholder you set when building
+     * the checkout (e.g. `route('vatly.return').'?checkout_id={CHECKOUT_ID}'`) —
+     * resolves the checkout's Vatly customer id, and, if a customer is attached,
+     * runs {@see self::claimVatlyCustomer()} to bind it and re-attribute this
+     * entity's previously-anonymous orders and subscriptions.
+     *
+     * Multi-tab safe by construction: each tab carries its own checkout id in
+     * its own redirect URL, so concurrent checkouts resolve independently —
+     * there is no shared session/cookie carrier whose last write wins.
+     *
+     * Returns whether a claim happened. Returns false (without throwing) for a
+     * missing / unknown checkout id, or a checkout with no customer yet — so it
+     * is safe to call unconditionally on the return route. A cross-host conflict
+     * (the id already bound to a different customer) still throws
+     * {@see CustomerAlreadyBoundException}.
+     *
+     * Out of scope: buyers who never return via the redirect link (closed tab,
+     * different device). That is the email-recovery story, handled separately.
+     */
+    public function claimVatlyCustomerFromReturn(Request $request, string $key = 'checkout_id'): bool
+    {
+        $checkoutId = $request->query($key);
+
+        if (! is_string($checkoutId) || $checkoutId === '') {
+            return false;
+        }
+
+        $customerId = app(Vatly::class)->customerIdFromCheckout($checkoutId);
+
+        if ($customerId === null) {
+            return false;
+        }
+
+        $this->claimVatlyCustomer($customerId);
+
+        return true;
     }
 
     // --- Static finders ---

--- a/tests/Feature/AnonymousCheckoutFlowTest.php
+++ b/tests/Feature/AnonymousCheckoutFlowTest.php
@@ -6,6 +6,8 @@ namespace Vatly\Laravel\Tests\Feature;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Vatly\Fluent\Exceptions\CustomerAlreadyBoundException;
 use Vatly\Fluent\SubscriptionHandle;
 use Vatly\Laravel\Models\Order;
 use Vatly\Laravel\Models\Subscription;
@@ -243,5 +245,108 @@ class AnonymousCheckoutFlowTest extends BaseTestCase
         $postSignupOrder = Order::where('vatly_id', 'order_post_signup')->firstOrFail();
         $this->assertSame($user->id, $postSignupOrder->owner_id);
         $this->assertSame('cus_charlie', $postSignupOrder->customer_id);
+    }
+
+    public function test_claim_from_return_resolves_the_right_customer_with_two_checkouts_in_flight(): void
+    {
+        // Two anonymous customers, each with their own subscription persisted
+        // via webhook, and each with their own checkout id (one browser tab
+        // per checkout — the multi-tab failure mode of a shared session).
+        $this->fakeGetSubscriptions([
+            'sub_alice' => $this->buildApiSubscription([
+                'id' => 'sub_alice', 'customerId' => 'cus_alice',
+                'subscriptionPlanId' => 'plan_basic', 'name' => 'Basic', 'quantity' => 1,
+            ]),
+            'sub_bob' => $this->buildApiSubscription([
+                'id' => 'sub_bob', 'customerId' => 'cus_bob',
+                'subscriptionPlanId' => 'plan_basic', 'name' => 'Basic', 'quantity' => 1,
+            ]),
+        ]);
+
+        $this->postWebhookEvent('subscription.started', 'sub_alice', 'subscription', [
+            'customerId' => 'cus_alice', 'subscriptionPlanId' => 'plan_basic', 'quantity' => 1, 'name' => 'Basic',
+        ])->assertStatus(201);
+        $this->postWebhookEvent('subscription.started', 'sub_bob', 'subscription', [
+            'customerId' => 'cus_bob', 'subscriptionPlanId' => 'plan_basic', 'quantity' => 1, 'name' => 'Basic',
+        ])->assertStatus(201);
+
+        // Both checkouts are resolvable; each carries its own customer.
+        $this->fakeGetCheckouts([
+            'checkout_alice' => $this->buildApiCheckout(['id' => 'checkout_alice', 'customerId' => 'cus_alice']),
+            'checkout_bob' => $this->buildApiCheckout(['id' => 'checkout_bob', 'customerId' => 'cus_bob']),
+        ]);
+
+        // Alice signs up and returns via HER checkout's redirect URL.
+        $alice = User::factory()->create(['email' => 'alice@example.test', 'vatly_id' => null]);
+
+        $claimed = $alice->claimVatlyCustomerFromReturn(
+            Request::create('/vatly/return', 'GET', ['checkout_id' => 'checkout_alice'])
+        );
+
+        $this->assertTrue($claimed);
+        $this->assertSame('cus_alice', $alice->fresh()->vatly_id);
+        $this->assertCount(1, $alice->fresh()->subscriptions);
+        $this->assertSame('sub_alice', $alice->fresh()->subscriptions->first()->vatly_id);
+
+        // Bob's purchase — opened in the other tab — is untouched.
+        $bobsSub = Subscription::where('vatly_id', 'sub_bob')->firstOrFail();
+        $this->assertNull($bobsSub->owner_id);
+        $this->assertSame('cus_bob', $bobsSub->customer_id);
+    }
+
+    public function test_claim_from_return_uses_a_custom_query_key(): void
+    {
+        $this->fakeGetCheckout($this->buildApiCheckout(['id' => 'checkout_x', 'customerId' => 'cus_x']));
+
+        $user = User::factory()->create(['vatly_id' => null]);
+
+        $claimed = $user->claimVatlyCustomerFromReturn(
+            Request::create('/vatly/return', 'GET', ['cid' => 'checkout_x']),
+            key: 'cid',
+        );
+
+        $this->assertTrue($claimed);
+        $this->assertSame('cus_x', $user->fresh()->vatly_id);
+    }
+
+    public function test_claim_from_return_throws_when_host_already_bound_to_a_different_customer(): void
+    {
+        $this->fakeGetCheckout($this->buildApiCheckout(['id' => 'checkout_x', 'customerId' => 'cus_new']));
+
+        // This user is already bound to a different Vatly customer.
+        $user = User::factory()->create(['vatly_id' => 'cus_existing']);
+
+        $this->expectException(CustomerAlreadyBoundException::class);
+
+        $user->claimVatlyCustomerFromReturn(
+            Request::create('/vatly/return', 'GET', ['checkout_id' => 'checkout_x'])
+        );
+    }
+
+    public function test_claim_from_return_is_a_noop_for_an_unknown_checkout_id(): void
+    {
+        // Any id resolves to a 404 — an unknown / expired / out-of-scope checkout.
+        $this->fakeGetCheckouts([]);
+
+        $user = User::factory()->create(['vatly_id' => null]);
+
+        $claimed = $user->claimVatlyCustomerFromReturn(
+            Request::create('/vatly/return', 'GET', ['checkout_id' => 'checkout_unknown'])
+        );
+
+        $this->assertFalse($claimed);
+        $this->assertNull($user->fresh()->vatly_id);
+    }
+
+    public function test_claim_from_return_is_a_noop_when_the_query_param_is_absent(): void
+    {
+        $user = User::factory()->create(['vatly_id' => null]);
+
+        $claimed = $user->claimVatlyCustomerFromReturn(
+            Request::create('/vatly/return', 'GET', [])
+        );
+
+        $this->assertFalse($claimed);
+        $this->assertNull($user->fresh()->vatly_id);
     }
 }

--- a/tests/TestHelpers/PostsVatlyWebhooks.php
+++ b/tests/TestHelpers/PostsVatlyWebhooks.php
@@ -7,6 +7,8 @@ namespace Vatly\Laravel\Tests\TestHelpers;
 use Illuminate\Testing\TestResponse;
 use Mockery;
 use ReflectionClass;
+use Vatly\API\Exceptions\ApiException;
+use Vatly\API\Resources\Checkout as ApiCheckout;
 use Vatly\API\Resources\Order as ApiOrder;
 use Vatly\API\Resources\Refund as ApiRefund;
 use Vatly\API\Resources\Subscription as ApiSubscription;
@@ -14,6 +16,7 @@ use Vatly\API\Types\Mandate;
 use Vatly\API\Types\Money;
 use Vatly\API\Types\TaxSummaryCollection;
 use Vatly\API\VatlyApiClient;
+use Vatly\Fluent\Actions\GetCheckout;
 use Vatly\Fluent\Actions\GetOrder;
 use Vatly\Fluent\Actions\GetRefund;
 use Vatly\Fluent\Actions\GetSubscription;
@@ -103,6 +106,55 @@ trait PostsVatlyWebhooks
         $this->writeVatlyPrivate($vatly, 'webhookProcessor', null);
 
         $this->app->forgetInstance(WebhookProcessor::class);
+    }
+
+    /**
+     * Replace the cached `GetCheckout` action on the composition root so the
+     * anonymous-checkout return flow (`claimVatlyCustomerFromReturn`) doesn't
+     * need a real API call. Convenience wrapper around
+     * {@see self::fakeGetCheckouts()} for a single checkout.
+     */
+    protected function fakeGetCheckout(ApiCheckout $checkout): void
+    {
+        $this->fakeGetCheckouts([$checkout->id => $checkout]);
+    }
+
+    /**
+     * Replace the cached `GetCheckout` action with a fake that returns a
+     * different `ApiCheckout` per checkout id — so a multi-tab scenario can
+     * keep several checkout ids in flight at once. An unregistered id throws a
+     * 404 `ApiException`, mirroring the real API for an unknown / out-of-scope
+     * checkout (which fluent maps to "nothing to claim").
+     *
+     * @param  array<string, ApiCheckout>  $checkouts  keyed by checkout id
+     */
+    protected function fakeGetCheckouts(array $checkouts): void
+    {
+        $action = Mockery::mock(GetCheckout::class);
+        $action->shouldReceive('execute')->andReturnUsing(function (string $id) use ($checkouts) {
+            if (isset($checkouts[$id])) {
+                return $checkouts[$id];
+            }
+
+            throw new ApiException("Error 404 executing API call for checkout '{$id}'", 404);
+        });
+
+        $this->writeVatlyPrivate($this->app->make(Vatly::class), 'getCheckout', $action);
+    }
+
+    /**
+     * Build a minimal ApiCheckout for `fakeGetCheckout()` callers.
+     *
+     * @param  array{id: string, customerId?: ?string, status?: string}  $data
+     */
+    protected function buildApiCheckout(array $data): ApiCheckout
+    {
+        $checkout = new ApiCheckout(Mockery::mock(VatlyApiClient::class));
+        $checkout->id = $data['id'];
+        $checkout->customerId = $data['customerId'] ?? null;
+        $checkout->status = $data['status'] ?? 'paid';
+
+        return $checkout;
     }
 
     /**


### PR DESCRIPTION
Closes the loop on anonymous / guest checkouts: how does your app learn which Vatly customer to claim when the buyer lands back on your site after a guest checkout?

## The flow

1. Build the checkout with the `{CHECKOUT_ID}` placeholder in the return URL — Vatly substitutes the real checkout id at creation:
   ```php
   $user->checkout()->create(
       items: [...],
       redirectUrlSuccess: route('vatly.return').'?checkout_id={CHECKOUT_ID}',
       redirectUrlCanceled: route('billing'),
   );
   ```
2. On the return route, call the new adapter:
   ```php
   $request->user()->claimVatlyCustomerFromReturn($request); // bool
   ```
   It reads `?checkout_id=…`, resolves the checkout's Vatly customer via fluent's `customerIdFromCheckout()`, and — when found — runs the existing `claimVatlyCustomer()`, so the guest's previously-anonymous orders/subscriptions are **re-attributed**, not just the binding written.

Returns `false` (no throw) for a missing / unknown checkout id or a checkout with no customer yet, so it's safe to call unconditionally. A cross-host conflict still throws `CustomerAlreadyBoundException`. Pass a second arg for a custom query key.

**Multi-tab safe by construction:** each tab carries its own checkout id in its own redirect URL — no shared session/cookie carrier whose last write wins.

## Why not the original #25 design

vatly-laravel#25 proposed a host-side token store + `rememberAtRedirectAs`. Once Vatly does `{CHECKOUT_ID}` URL templating (vatlify side) the token store is unnecessary, and the resolution logic is a reusable fluent primitive — so this driver stays a ~6-line adapter. See the fluent PR for the rationale.

## Tests & docs

- Feature tests: multi-tab (two checkouts in flight, only the right customer claimed), custom query key, cross-host conflict, unknown id, absent param. New `fakeGetCheckout`/`fakeGetCheckouts`/`buildApiCheckout` helpers mirror the order/subscription fakes.
- Docs: rewrote the "Anonymous / guest checkouts" section (Customers.md + README) to the new flow; dropped the "plumb the `cus_` yourself" hand-wave; noted the id travels in URL/referer/logs (low sensitivity); kept closed-tab / never-returned (email recovery) explicitly out of scope.

## ⚠️ Dependency / merge order

Depends on **vatly-fluent-php alpha.9** (`customerIdFromCheckout`/`claimCustomerFromCheckout`) → which depends on **vatly-api-php alpha.13** (`Checkout::$customerId`) → which pairs with the **vatlify** checkout-payload + `{CHECKOUT_ID}` change. `composer.json` already pins `^0.8.0-alpha.9` (on main). **CI will be red until fluent alpha.9 is released.** Verified locally green against the upstream branches: `composer test` (69 tests) ✓, `composer analyse` ✓, `pint --test` ✓.