### PR TITLE
feat: adopt vatly-fluent-php alpha.11 — checkout + grace-period-completed events

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,12 +153,14 @@ Events available:
 - `Vatly\Fluent\Events\OrderCanceled` — the local order's status is mirrored to `canceled`.
 - `Vatly\Fluent\Events\OrderChargebackReceived` / `OrderChargebackReversed` — dispute signals carrying the affected `orderId` (no local row is mutated; react to suspend/reinstate access).
 - `Vatly\Fluent\Events\PaymentFailed` — same enriched order shape as `OrderPaid`; typically the start of dunning.
+- `Vatly\Fluent\Events\CheckoutPaid` / `CheckoutFailed` / `CheckoutCanceled` / `CheckoutExpired` — hosted-checkout lifecycle signals carrying `checkoutId`, nullable `customerId` / `orderId`, `status` and `metadata`. Dispatched straight from the payload (no enrichment GET, no local row); `CheckoutPaid` fires before `OrderPaid` so you can drive in-app receipt/analytics UI, while the others feed retry / cart-abandonment flows.
 - `Vatly\Fluent\Events\RefundCompleted` / `RefundFailed` / `RefundCanceled` — each with full `taxSummary`; persisted to `vatly_refunds` (see below).
 - `Vatly\Fluent\Events\SubscriptionStarted`
 - `Vatly\Fluent\Events\SubscriptionBillingUpdated` — the stored mandate (`mandate_method` / `mandate_masked_identifier`) is refreshed.
 - `Vatly\Fluent\Events\SubscriptionResumed` — the stored end date is cleared.
 - `Vatly\Fluent\Events\SubscriptionCanceledImmediately`
 - `Vatly\Fluent\Events\SubscriptionCanceledWithGracePeriod`
+- `Vatly\Fluent\Events\SubscriptionCancellationGracePeriodCompleted` — the grace period set at cancellation has elapsed; carries `customerId`, `subscriptionId`, `endsAt`. No local write (the cancellation already stamped `ends_at`) — listen to flip your own application-level "fully ended" state without polling.
 - `Vatly\Fluent\Events\LocalSubscriptionCreated`
 - `Vatly\Fluent\Events\UnsupportedWebhookReceived`
 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "illuminate/http": "^12.0|^13.0",
         "illuminate/routing": "^12.0|^13.0",
         "illuminate/support": "^12.0|^13.0",
-        "vatly/vatly-fluent-php": "^0.8.0-alpha.10"
+        "vatly/vatly-fluent-php": "^0.8.0-alpha.11"
     },
     "require-dev": {
         "larastan/larastan": "^3.9",

--- a/docs/Webhooks.md
+++ b/docs/Webhooks.md
@@ -33,8 +33,13 @@ When a webhook is received, the driver's `LaravelEventDispatcher` forwards fluen
 | `SubscriptionStarted` | A `subscription.started` webhook is received |
 | `SubscriptionCanceledImmediately` | A `subscription.canceled_immediately` webhook is received |
 | `SubscriptionCanceledWithGracePeriod` | A `subscription.canceled_with_grace_period` webhook is received |
+| `SubscriptionCancellationGracePeriodCompleted` | A `subscription.cancellation_grace_period_completed` webhook is received — the grace period stamped by the cancellation has now elapsed (carries `customerId`, `subscriptionId`, `endsAt`) |
 | `OrderPaid` | An `order.paid` webhook is received (enriched with the full tax breakdown) |
 | `PaymentFailed` | A `payment.failed` webhook is received — typically the start of dunning (enriched with the full tax breakdown) |
+| `CheckoutPaid` | A `checkout.paid` webhook is received — the hosted checkout was paid (fires before `order.paid`'s enrichment GET; carries `checkoutId`, nullable `customerId` / `orderId`, `status`, `metadata`) |
+| `CheckoutFailed` | A `checkout.failed` webhook is received — the hosted checkout's payment failed (route into a retry flow) |
+| `CheckoutCanceled` | A `checkout.canceled` webhook is received — the customer abandoned the hosted checkout (cart-abandonment hook) |
+| `CheckoutExpired` | A `checkout.expired` webhook is received — the hosted checkout session timed out without completion |
 | `UnsupportedWebhookReceived` | A webhook arrives that has no typed mapping (carries the raw `eventName` / `object`) |
 | `LocalSubscriptionCreated` | A new local `Subscription` row was just created from a `subscription.started` webhook (application-level event; carries the stored `$subscription`) |
 
@@ -48,6 +53,8 @@ Before the event is dispatched, the package keeps your local tables in sync auto
 - **`CancelSubscriptionOnCanceled`** -- On `SubscriptionCanceledImmediately` / `SubscriptionCanceledWithGracePeriod`, sets the local subscription's `ends_at`.
 - **`StoreOrderOnPaid`** -- On `OrderPaid`, stores (or updates) the local `Order` row.
 - **`StoreOrderOnPaymentFailed`** -- On `PaymentFailed`, stores (or updates) the local `Order` row, mirroring the upstream order status verbatim.
+
+The checkout events (`CheckoutPaid` / `CheckoutFailed` / `CheckoutCanceled` / `CheckoutExpired`) and `SubscriptionCancellationGracePeriodCompleted` ship no built-in reaction — they touch no local table. The checkout payloads carry the full Checkout resource (so they're dispatched without an enrichment GET), and the grace-period-completed transition needs no write because the cancellation that scheduled the grace period already stamped `ends_at` onto the local subscription. Listen for them directly to drive receipt/retry/cart-abandonment UI or to flip your own application-level state.
 
 ## Custom listeners
 

--- a/tests/Http/Controllers/VatlyInboundWebhookControllerTest.php
+++ b/tests/Http/Controllers/VatlyInboundWebhookControllerTest.php
@@ -8,6 +8,9 @@ use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Event;
 use Vatly\API\Types\Mandate;
+use Vatly\Fluent\Events\CheckoutCanceled;
+use Vatly\Fluent\Events\CheckoutExpired;
+use Vatly\Fluent\Events\CheckoutFailed;
 use Vatly\Fluent\Events\CheckoutPaid;
 use Vatly\Fluent\Events\PaymentFailed;
 use Vatly\Fluent\Events\SubscriptionCancellationGracePeriodCompleted;
@@ -293,6 +296,71 @@ class VatlyInboundWebhookControllerTest extends BaseTestCase
                 && $event->orderId === 'order_abc123'
                 && $event->status === 'paid'
                 && $event->metadata === ['cart' => 'cart_1'],
+        );
+    }
+
+    public function test_it_dispatches_the_checkout_failed_event_from_webhook(): void
+    {
+        Event::fake([CheckoutFailed::class]);
+
+        $this->postWebhookEvent('checkout.failed', 'checkout_failed_1', 'checkout', [
+            'customerId' => 'customer_abc',
+            'orderId' => null,
+            'status' => 'failed',
+            'metadata' => ['cart' => 'cart_2'],
+        ])->assertStatus(201);
+
+        $this->assertDatabaseCount('vatly_webhook_calls', 1);
+
+        Event::assertDispatched(
+            CheckoutFailed::class,
+            fn (CheckoutFailed $event): bool => $event->checkoutId === 'checkout_failed_1'
+                && $event->customerId === 'customer_abc'
+                && $event->orderId === null
+                && $event->status === 'failed'
+                && $event->metadata === ['cart' => 'cart_2'],
+        );
+    }
+
+    public function test_it_dispatches_the_checkout_canceled_event_from_webhook(): void
+    {
+        Event::fake([CheckoutCanceled::class]);
+
+        $this->postWebhookEvent('checkout.canceled', 'checkout_canceled_1', 'checkout', [
+            'customerId' => 'customer_abc',
+            'orderId' => null,
+            'status' => 'canceled',
+        ])->assertStatus(201);
+
+        $this->assertDatabaseCount('vatly_webhook_calls', 1);
+
+        Event::assertDispatched(
+            CheckoutCanceled::class,
+            fn (CheckoutCanceled $event): bool => $event->checkoutId === 'checkout_canceled_1'
+                && $event->customerId === 'customer_abc'
+                && $event->orderId === null
+                && $event->status === 'canceled',
+        );
+    }
+
+    public function test_it_dispatches_the_checkout_expired_event_from_webhook(): void
+    {
+        Event::fake([CheckoutExpired::class]);
+
+        $this->postWebhookEvent('checkout.expired', 'checkout_expired_1', 'checkout', [
+            'customerId' => null,
+            'orderId' => null,
+            'status' => 'expired',
+        ])->assertStatus(201);
+
+        $this->assertDatabaseCount('vatly_webhook_calls', 1);
+
+        Event::assertDispatched(
+            CheckoutExpired::class,
+            fn (CheckoutExpired $event): bool => $event->checkoutId === 'checkout_expired_1'
+                && $event->customerId === null
+                && $event->orderId === null
+                && $event->status === 'expired',
         );
     }
 

--- a/tests/Http/Controllers/VatlyInboundWebhookControllerTest.php
+++ b/tests/Http/Controllers/VatlyInboundWebhookControllerTest.php
@@ -8,7 +8,9 @@ use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Event;
 use Vatly\API\Types\Mandate;
+use Vatly\Fluent\Events\CheckoutPaid;
 use Vatly\Fluent\Events\PaymentFailed;
+use Vatly\Fluent\Events\SubscriptionCancellationGracePeriodCompleted;
 use Vatly\Laravel\Models\Order;
 use Vatly\Laravel\Models\Refund;
 use Vatly\Laravel\Models\Subscription;
@@ -268,6 +270,48 @@ class VatlyInboundWebhookControllerTest extends BaseTestCase
             PaymentFailed::class,
             fn (PaymentFailed $event): bool => $event->orderId === 'order_failed_2'
                 && $event->customerId === 'customer_abc',
+        );
+    }
+
+    public function test_it_dispatches_the_checkout_paid_event_from_webhook(): void
+    {
+        Event::fake([CheckoutPaid::class]);
+
+        $this->postWebhookEvent('checkout.paid', 'checkout_abc123', 'checkout', [
+            'customerId' => 'customer_abc',
+            'orderId' => 'order_abc123',
+            'status' => 'paid',
+            'metadata' => ['cart' => 'cart_1'],
+        ])->assertStatus(201);
+
+        $this->assertDatabaseCount('vatly_webhook_calls', 1);
+
+        Event::assertDispatched(
+            CheckoutPaid::class,
+            fn (CheckoutPaid $event): bool => $event->checkoutId === 'checkout_abc123'
+                && $event->customerId === 'customer_abc'
+                && $event->orderId === 'order_abc123'
+                && $event->status === 'paid'
+                && $event->metadata === ['cart' => 'cart_1'],
+        );
+    }
+
+    public function test_it_dispatches_the_grace_period_completed_event_from_webhook(): void
+    {
+        Event::fake([SubscriptionCancellationGracePeriodCompleted::class]);
+
+        $this->postWebhookEvent('subscription.cancellation_grace_period_completed', 'sub_grace', 'subscription', [
+            'customerId' => 'customer_abc',
+            'endedAt' => '2026-01-01T00:00:00+00:00',
+        ])->assertStatus(201);
+
+        $this->assertDatabaseCount('vatly_webhook_calls', 1);
+
+        Event::assertDispatched(
+            SubscriptionCancellationGracePeriodCompleted::class,
+            fn (SubscriptionCancellationGracePeriodCompleted $event): bool => $event->subscriptionId === 'sub_grace'
+                && $event->customerId === 'customer_abc'
+                && $event->endsAt->format('Y-m-d') === '2026-01-01',
         );
     }
 


### PR DESCRIPTION
Adopts [vatly-fluent-php v0.8.0-alpha.11](https://github.com/vatly/vatly-fluent-php/releases/tag/v0.8.0-alpha.11). Bumps `vatly/vatly-fluent-php` `^0.8.0-alpha.10` → `^0.8.0-alpha.11` (pulling vatly-api-php alpha.13) and wires up the five new typed webhook events.

## Back-compat check
alpha.11 adds events only — no `WebhookEventFactory` / `Wiring` signature change ("fully back-compatible" per the release notes). This package routes everything through fluent's `WebhookProcessor` via `Vatly::webhookProcessor()`, so the new events flow through with no wiring changes. Verified by the full suite passing against alpha.11.

## New events
All five are **dispatched-only** — no built-in reaction, no new local table:

- `CheckoutPaid` / `CheckoutFailed` / `CheckoutCanceled` / `CheckoutExpired` (`checkout.*`) — hosted-checkout lifecycle signals carrying `checkoutId`, nullable `customerId` / `orderId`, `status`, `metadata`. Built straight from the payload (the checkout deliveries carry the full Checkout resource, so no enrichment GET). `CheckoutPaid` fires before `OrderPaid` for in-app receipt/analytics UI; the others feed retry / cart-abandonment flows. `customerId` is nullable since an anonymous checkout only gets a customer on payment completion.
- `SubscriptionCancellationGracePeriodCompleted` (`subscription.cancellation_grace_period_completed`) — the grace period set at cancellation has elapsed. No local write: the cancellation already stamped `ends_at`, so the derived "ended" state is already correct once the clock passes. Listen to flip your own application-level "fully ended" state without polling.

## Changes
- `composer.json` — version bump.
- `README.md` + `docs/Webhooks.md` — added the new events to the event list / events table, with a note on why they're dispatch-only.
- `tests/` — two end-to-end dispatch tests (`checkout.paid`, `subscription.cancellation_grace_period_completed`).

## Verification
- `composer test` — 71 tests, 189 assertions, all pass.
- Pint clean.
- PHPStan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)