### PR TITLE
ci: run PHPStan in CI

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -1,0 +1,28 @@
+name: PHPStan
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  phpstan:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.3
+          extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pdo_sqlite
+          coverage: none
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Run PHPStan
+        run: composer analyse


### PR DESCRIPTION
Closes the gap that surfaced while adopting alpha.11/alpha.12 (#33, #34): the repo has `larastan/larastan`, a tuned `phpstan.neon`, and a `composer analyse` script — but **no workflow ran them**, so static-analysis errors could merge green.

Adds a `PHPStan` workflow mirroring `pint.yml` (single job, PHP 8.3). The `analyse` script already sets `--memory-limit=512M` (the 128M default OOMs on this codebase).

🤖 Generated with [Claude Code](https://claude.com/claude-code)