### PR TITLE
feat: adopt vatly-fluent-php alpha.13 — chargeback persistence + refund read surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,12 @@ foreach ($user->orders as $order) {
 // Or explicit lookup
 $invoiceUrl = $user->order('order_abc')->invoiceUrl();
 
+// Refunds & chargebacks — owned-by-customer and per-order relations
+$user->refunds;                                         // all refunds for this customer
+$user->chargebacks;                                     // all chargebacks (disputes) for this customer
+$order->refunds;                                        // refunds against this order
+$order->chargebacks;                                    // chargebacks against this order
+
 // Static finders
 $user = User::findBillable('customer_xyz');             // ?User
 $user = User::findBillableOrFail('customer_xyz');       // User

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Pin to an exact version during alpha — the API will change.
    php artisan migrate
    ```
 
-   This adds a `vatly_id` column to your users table plus `vatly_subscriptions`, `vatly_orders`, `vatly_refunds`, and `vatly_webhook_calls` tables.
+   This adds a `vatly_id` column to your users table plus `vatly_subscriptions`, `vatly_orders`, `vatly_refunds`, `vatly_chargebacks`, and `vatly_webhook_calls` tables.
 
 4. **Add the `Billable` trait to your User model:**
 
@@ -151,7 +151,7 @@ Events available:
 
 - `Vatly\Fluent\Events\OrderPaid` — carries `total`, `subtotal`, `taxSummary` (full per-rate breakdown), `currency`, `invoiceNumber`, `paymentMethod`. Materialize local invoices without an extra API call.
 - `Vatly\Fluent\Events\OrderCanceled` — the local order's status is mirrored to `canceled`.
-- `Vatly\Fluent\Events\OrderChargebackReceived` / `OrderChargebackReversed` — dispute signals carrying the affected `orderId` (no local row is mutated; react to suspend/reinstate access).
+- `Vatly\Fluent\Events\OrderChargebackReceived` / `OrderChargebackReversed` — dispute signals carrying the affected `orderId`, enriched with `customerId`, dispute `status`, totals and `taxSummary`; persisted to `vatly_chargebacks` (see below). Also react to suspend/reinstate access — a chargeback never mutates the local order row.
 - `Vatly\Fluent\Events\PaymentFailed` — same enriched order shape as `OrderPaid`; typically the start of dunning.
 - `Vatly\Fluent\Events\CheckoutPaid` / `CheckoutFailed` / `CheckoutCanceled` / `CheckoutExpired` — hosted-checkout lifecycle signals carrying `checkoutId`, nullable `customerId` / `orderId`, `status` and `metadata`. Dispatched straight from the payload (no enrichment GET, no local row); `CheckoutPaid` fires before `OrderPaid` so you can drive in-app receipt/analytics UI, while the others feed retry / cart-abandonment flows.
 - `Vatly\Fluent\Events\RefundCompleted` / `RefundFailed` / `RefundCanceled` — each with full `taxSummary`; persisted to `vatly_refunds` (see below).
@@ -164,7 +164,7 @@ Events available:
 - `Vatly\Fluent\Events\LocalSubscriptionCreated`
 - `Vatly\Fluent\Events\UnsupportedWebhookReceived`
 
-Refund webhooks (`refund.completed` / `refund.failed` / `refund.canceled`) are persisted to the `vatly_refunds` table via the bundled `Refund` model and `EloquentRefundRepository`. Chargeback events ship no built-in persistence — Vatly's public order status doesn't change on a chargeback, so wire your own listener if you need to suspend/reinstate access.
+Refund webhooks (`refund.completed` / `refund.failed` / `refund.canceled`) are persisted to the `vatly_refunds` table via the bundled `Refund` model and `EloquentRefundRepository`. Chargeback webhooks (`order.chargeback_received` / `order.chargeback_reversed`) are persisted the same way to the `vatly_chargebacks` table via the bundled `Chargeback` model and `EloquentChargebackRepository` — Vatly's public order status doesn't change on a chargeback, so also wire your own listener if you need to suspend/reinstate access.
 
 The webhook route is named `vatly.webhook` — reach it with `route('vatly.webhook')`.
 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "illuminate/http": "^12.0|^13.0",
         "illuminate/routing": "^12.0|^13.0",
         "illuminate/support": "^12.0|^13.0",
-        "vatly/vatly-fluent-php": "^0.8.0-alpha.12"
+        "vatly/vatly-fluent-php": "^0.8.0-alpha.13"
     },
     "require-dev": {
         "larastan/larastan": "^3.9",

--- a/database/migrations/create_vatly_chargebacks_table.php.stub
+++ b/database/migrations/create_vatly_chargebacks_table.php.stub
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('vatly_chargebacks', function (Blueprint $table) {
+            $table->id();
+            $table->nullableMorphs('owner');
+            $table->string('vatly_id')->unique();
+            $table->string('original_order_id')->index();
+            $table->string('status');
+            $table->integer('total');
+            $table->integer('subtotal')->nullable();
+            $table->json('tax_summary')->nullable();
+            $table->string('currency', 3);
+            $table->string('reason')->nullable();
+            $table->string('customer_id')->nullable()->index();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('vatly_chargebacks');
+    }
+};

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -39,6 +39,9 @@ parameters:
         -
             message: '#^Method Vatly\\Laravel\\Models\\Refund::owner\(\) should return Illuminate\\Database\\Eloquent\\Relations\\MorphTo.+ but returns .+\.$#'
             path: src/Models/Refund.php
+        -
+            message: '#^Method Vatly\\Laravel\\Models\\Chargeback::owner\(\) should return Illuminate\\Database\\Eloquent\\Relations\\MorphTo.+ but returns .+\.$#'
+            path: src/Models/Chargeback.php
 
         # Model uses Billable trait which adds vatlyId() method
         -

--- a/src/Billable.php
+++ b/src/Billable.php
@@ -16,7 +16,9 @@ use Vatly\Fluent\OrderHandle;
 use Vatly\Fluent\SubscriptionHandle;
 use Vatly\Fluent\Vatly;
 use Vatly\Laravel\Exceptions\NoVatlyCustomerException;
+use Vatly\Laravel\Models\Chargeback;
 use Vatly\Laravel\Models\Order;
+use Vatly\Laravel\Models\Refund;
 use Vatly\Laravel\Models\Subscription;
 
 /**
@@ -87,6 +89,22 @@ trait Billable
     public function orders(): MorphMany
     {
         return $this->morphMany(Order::class, 'owner')->orderByDesc('created_at');
+    }
+
+    /**
+     * @return MorphMany<Refund>
+     */
+    public function refunds(): MorphMany
+    {
+        return $this->morphMany(Refund::class, 'owner')->orderByDesc('created_at');
+    }
+
+    /**
+     * @return MorphMany<Chargeback>
+     */
+    public function chargebacks(): MorphMany
+    {
+        return $this->morphMany(Chargeback::class, 'owner')->orderByDesc('created_at');
     }
 
     // --- Subscription accessors ---

--- a/src/Models/Chargeback.php
+++ b/src/Models/Chargeback.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Laravel\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Vatly\Fluent\Contracts\ChargebackInterface;
+
+/**
+ * @property string $vatly_id
+ * @property string|null $owner_type
+ * @property int|null $owner_id
+ * @property string|null $customer_id The Vatly customer id (cus_…).
+ * @property string $original_order_id The Vatly id of the order the chargeback was raised against.
+ * @property string $status
+ * @property int $total
+ * @property int|null $subtotal
+ * @property array<int, array{rate: array{name: string, percentage: float, taxablePercentage: float}, amount: int, currency: string}>|null $tax_summary
+ * @property string $currency
+ * @property string|null $reason
+ *
+ * @method static create(array<string, mixed> $array)
+ * @method static where(string $column, mixed $value)
+ */
+class Chargeback extends Model implements ChargebackInterface
+{
+    protected $table = 'vatly_chargebacks';
+
+    protected $guarded = [];
+
+    /**
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'tax_summary' => 'array',
+    ];
+
+    /**
+     * @return MorphTo<Model, Chargeback>
+     */
+    public function owner(): MorphTo
+    {
+        return $this->morphTo('owner');
+    }
+
+    // ChargebackInterface implementation
+
+    public function getVatlyId(): string
+    {
+        return $this->vatly_id;
+    }
+
+    public function getStatus(): string
+    {
+        return $this->status;
+    }
+
+    public function getTotal(): int
+    {
+        return (int) $this->total;
+    }
+
+    public function getCurrency(): string
+    {
+        return $this->currency;
+    }
+
+    public function getOriginalOrderId(): string
+    {
+        return $this->original_order_id;
+    }
+
+    public function getReason(): ?string
+    {
+        return $this->reason;
+    }
+
+    public function isReversed(): bool
+    {
+        // Dispute lifecycle: pending, accepted, rejected, evidence_submitted,
+        // won, lost. A reversal — funds returned to the merchant — is "won".
+        return $this->status === 'won';
+    }
+}

--- a/src/Models/Order.php
+++ b/src/Models/Order.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Vatly\Laravel\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Vatly\Fluent\Contracts\OrderInterface;
 use Vatly\Fluent\OrderHandle;
@@ -45,6 +46,35 @@ class Order extends Model implements OrderInterface
     public function owner(): MorphTo
     {
         return $this->morphTo('owner');
+    }
+
+    /**
+     * Refunds issued against this order.
+     *
+     * Linked on the Vatly order id (`original_order_id` → `vatly_id`) rather
+     * than the local primary key, since refund rows reference the order by its
+     * Vatly id.
+     *
+     * @return HasMany<Refund, $this>
+     */
+    public function refunds(): HasMany
+    {
+        return $this->hasMany(Refund::class, 'original_order_id', 'vatly_id')
+            ->orderByDesc('created_at');
+    }
+
+    /**
+     * Chargebacks raised against this order.
+     *
+     * Linked on the Vatly order id (`original_order_id` → `vatly_id`), mirroring
+     * {@see self::refunds()}.
+     *
+     * @return HasMany<Chargeback, $this>
+     */
+    public function chargebacks(): HasMany
+    {
+        return $this->hasMany(Chargeback::class, 'original_order_id', 'vatly_id')
+            ->orderByDesc('created_at');
     }
 
     // OrderInterface implementation

--- a/src/Repositories/EloquentChargebackRepository.php
+++ b/src/Repositories/EloquentChargebackRepository.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Laravel\Repositories;
+
+use Vatly\Fluent\Contracts\ChargebackInterface;
+use Vatly\Fluent\Contracts\ChargebackRepositoryInterface;
+use Vatly\Fluent\Data\StoreChargebackData;
+use Vatly\Fluent\Data\UpdateChargebackData;
+use Vatly\Laravel\Models\Chargeback;
+use Vatly\Laravel\VatlyConfig;
+
+class EloquentChargebackRepository implements ChargebackRepositoryInterface
+{
+    public function __construct(
+        private readonly VatlyConfig $config,
+    ) {
+        //
+    }
+
+    public function findByVatlyId(string $vatlyId): ?ChargebackInterface
+    {
+        return Chargeback::where('vatly_id', $vatlyId)->first();
+    }
+
+    /**
+     * @return ChargebackInterface[]
+     */
+    public function listForCustomer(string $customerId): array
+    {
+        return Chargeback::where('customer_id', $customerId)->get()->all();
+    }
+
+    /**
+     * @return ChargebackInterface[]
+     */
+    public function listForOrder(string $vatlyOrderId): array
+    {
+        return Chargeback::where('original_order_id', $vatlyOrderId)->get()->all();
+    }
+
+    public function store(StoreChargebackData $data): ?ChargebackInterface
+    {
+        $attrs = [
+            'vatly_id' => $data->vatlyId,
+            'customer_id' => $data->customerId,
+            'original_order_id' => $data->originalOrderId,
+            'status' => $data->status,
+            'total' => $data->total,
+            'subtotal' => $data->subtotal,
+            'tax_summary' => $data->taxSummary?->toArray(),
+            'currency' => $data->currency,
+            'reason' => $data->reason,
+        ];
+
+        if ($data->hostCustomerId !== null) {
+            $model = $this->config->getBillableModel();
+            $attrs['owner_type'] = (new $model)->getMorphClass();
+            $attrs['owner_id'] = $data->hostCustomerId;
+        }
+
+        return Chargeback::create($attrs);
+    }
+
+    public function update(ChargebackInterface $chargeback, UpdateChargebackData $data): ChargebackInterface
+    {
+        if ($chargeback instanceof Chargeback) {
+            if ($data->status !== null) {
+                $chargeback->status = $data->status;
+            }
+            if ($data->total !== null) {
+                $chargeback->total = $data->total;
+            }
+            if ($data->subtotal !== null) {
+                $chargeback->subtotal = $data->subtotal;
+            }
+            if ($data->taxSummary !== null) {
+                $chargeback->tax_summary = $data->taxSummary->toArray();
+            }
+            if ($data->currency !== null) {
+                $chargeback->currency = $data->currency;
+            }
+            if ($data->reason !== null) {
+                $chargeback->reason = $data->reason;
+            }
+            $chargeback->save();
+        }
+
+        return $chargeback;
+    }
+}

--- a/src/Repositories/EloquentRefundRepository.php
+++ b/src/Repositories/EloquentRefundRepository.php
@@ -24,6 +24,22 @@ class EloquentRefundRepository implements RefundRepositoryInterface
         return Refund::where('vatly_id', $vatlyId)->first();
     }
 
+    /**
+     * @return RefundInterface[]
+     */
+    public function listForCustomer(string $customerId): array
+    {
+        return Refund::where('customer_id', $customerId)->get()->all();
+    }
+
+    /**
+     * @return RefundInterface[]
+     */
+    public function listForOrder(string $vatlyOrderId): array
+    {
+        return Refund::where('original_order_id', $vatlyOrderId)->get()->all();
+    }
+
     public function store(StoreRefundData $data): RefundInterface
     {
         $attrs = [

--- a/src/VatlyServiceProvider.php
+++ b/src/VatlyServiceProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Vatly\Laravel;
 
 use Illuminate\Support\ServiceProvider;
+use Vatly\Fluent\Contracts\ChargebackRepositoryInterface;
 use Vatly\Fluent\Contracts\ConfigurationInterface;
 use Vatly\Fluent\Contracts\CustomerBindingRepository;
 use Vatly\Fluent\Contracts\EventDispatcherInterface;
@@ -16,6 +17,7 @@ use Vatly\Fluent\Vatly;
 use Vatly\Fluent\Webhooks\WebhookProcessor;
 use Vatly\Fluent\Wiring;
 use Vatly\Laravel\Events\LaravelEventDispatcher;
+use Vatly\Laravel\Repositories\EloquentChargebackRepository;
 use Vatly\Laravel\Repositories\EloquentCustomerBindingRepository;
 use Vatly\Laravel\Repositories\EloquentOrderRepository;
 use Vatly\Laravel\Repositories\EloquentRefundRepository;
@@ -34,6 +36,7 @@ class VatlyServiceProvider extends ServiceProvider
         $this->app->bind(SubscriptionRepositoryInterface::class, EloquentSubscriptionRepository::class);
         $this->app->bind(OrderRepositoryInterface::class, EloquentOrderRepository::class);
         $this->app->bind(RefundRepositoryInterface::class, EloquentRefundRepository::class);
+        $this->app->bind(ChargebackRepositoryInterface::class, EloquentChargebackRepository::class);
         $this->app->bind(WebhookCallRepositoryInterface::class, EloquentWebhookCallRepository::class);
         $this->app->bind(CustomerBindingRepository::class, EloquentCustomerBindingRepository::class);
         $this->app->bind(EventDispatcherInterface::class, LaravelEventDispatcher::class);
@@ -44,6 +47,7 @@ class VatlyServiceProvider extends ServiceProvider
             subscriptions: $app->make(SubscriptionRepositoryInterface::class),
             orders: $app->make(OrderRepositoryInterface::class),
             refunds: $app->make(RefundRepositoryInterface::class),
+            chargebacks: $app->make(ChargebackRepositoryInterface::class),
             webhookCalls: $app->make(WebhookCallRepositoryInterface::class),
             events: $app->make(EventDispatcherInterface::class),
             customerBindings: $app->make(CustomerBindingRepository::class),
@@ -82,6 +86,7 @@ class VatlyServiceProvider extends ServiceProvider
             __DIR__.'/../database/migrations/create_vatly_webhook_calls_table.php.stub' => $this->getMigrationFileName('create_vatly_webhook_calls_table.php'),
             __DIR__.'/../database/migrations/create_vatly_orders_table.php.stub' => $this->getMigrationFileName('create_vatly_orders_table.php'),
             __DIR__.'/../database/migrations/create_vatly_refunds_table.php.stub' => $this->getMigrationFileName('create_vatly_refunds_table.php'),
+            __DIR__.'/../database/migrations/create_vatly_chargebacks_table.php.stub' => $this->getMigrationFileName('create_vatly_chargebacks_table.php'),
         ], 'vatly-migrations');
     }
 

--- a/tests/BillableTraitTest.php
+++ b/tests/BillableTraitTest.php
@@ -14,7 +14,9 @@ use Vatly\Fluent\Exceptions\InvalidOrderException;
 use Vatly\Fluent\OrderHandle;
 use Vatly\Fluent\SubscriptionHandle;
 use Vatly\Fluent\Vatly;
+use Vatly\Laravel\Models\Chargeback;
 use Vatly\Laravel\Models\Order;
+use Vatly\Laravel\Models\Refund;
 use Vatly\Laravel\Models\Subscription;
 
 class BillableTraitTest extends BaseTestCase
@@ -113,6 +115,57 @@ class BillableTraitTest extends BaseTestCase
         $user = User::factory()->create();
 
         $this->assertInstanceOf(CheckoutBuilder::class, $user->checkout());
+    }
+
+    public function test_refunds_relation_returns_owned_refunds(): void
+    {
+        $user = User::factory()->create(['vatly_id' => 'customer_refunds']);
+
+        Refund::create([
+            'owner_type' => $user->getMorphClass(),
+            'owner_id' => $user->getKey(),
+            'vatly_id' => 'refund_owned',
+            'original_order_id' => 'order_1',
+            'status' => 'refunded',
+            'total' => 9900,
+            'currency' => 'EUR',
+        ]);
+        // A refund owned by nobody (anonymous flow) must not leak in.
+        Refund::create([
+            'vatly_id' => 'refund_orphan',
+            'original_order_id' => 'order_2',
+            'status' => 'refunded',
+            'total' => 100,
+            'currency' => 'EUR',
+        ]);
+
+        $this->assertCount(1, $user->refunds);
+        $this->assertSame('refund_owned', $user->refunds->first()->getVatlyId());
+    }
+
+    public function test_chargebacks_relation_returns_owned_chargebacks(): void
+    {
+        $user = User::factory()->create(['vatly_id' => 'customer_chargebacks']);
+
+        Chargeback::create([
+            'owner_type' => $user->getMorphClass(),
+            'owner_id' => $user->getKey(),
+            'vatly_id' => 'chargeback_owned',
+            'original_order_id' => 'order_1',
+            'status' => 'pending',
+            'total' => 9900,
+            'currency' => 'EUR',
+        ]);
+        Chargeback::create([
+            'vatly_id' => 'chargeback_orphan',
+            'original_order_id' => 'order_2',
+            'status' => 'pending',
+            'total' => 100,
+            'currency' => 'EUR',
+        ]);
+
+        $this->assertCount(1, $user->chargebacks);
+        $this->assertSame('chargeback_owned', $user->chargebacks->first()->getVatlyId());
     }
 
     public function test_vatly_accessors_read_eloquent_columns(): void

--- a/tests/Fixtures/migrations/2024_01_01_000002_create_vatly_tables.php
+++ b/tests/Fixtures/migrations/2024_01_01_000002_create_vatly_tables.php
@@ -53,6 +53,21 @@ return new class extends Migration
             $table->timestamps();
         });
 
+        Schema::create('vatly_chargebacks', function (Blueprint $table) {
+            $table->id();
+            $table->nullableMorphs('owner');
+            $table->string('vatly_id')->unique();
+            $table->string('original_order_id')->index();
+            $table->string('status');
+            $table->integer('total');
+            $table->integer('subtotal')->nullable();
+            $table->json('tax_summary')->nullable();
+            $table->string('currency');
+            $table->string('reason')->nullable();
+            $table->string('customer_id')->nullable()->index();
+            $table->timestamps();
+        });
+
         Schema::create('vatly_webhook_calls', function (Blueprint $table) {
             $table->id();
             $table->timestamps();

--- a/tests/Http/Controllers/VatlyInboundWebhookControllerTest.php
+++ b/tests/Http/Controllers/VatlyInboundWebhookControllerTest.php
@@ -14,6 +14,7 @@ use Vatly\Fluent\Events\CheckoutFailed;
 use Vatly\Fluent\Events\CheckoutPaid;
 use Vatly\Fluent\Events\PaymentFailed;
 use Vatly\Fluent\Events\SubscriptionCancellationGracePeriodCompleted;
+use Vatly\Laravel\Models\Chargeback;
 use Vatly\Laravel\Models\Order;
 use Vatly\Laravel\Models\Refund;
 use Vatly\Laravel\Models\Subscription;
@@ -505,5 +506,92 @@ class VatlyInboundWebhookControllerTest extends BaseTestCase
         $this->assertSame(8182, $refund->subtotal);
         $this->assertSame(1718, $refund->tax_summary[0]['amount']);
         $this->assertTrue($refund->isCompleted());
+    }
+
+    public function test_it_persists_a_chargeback_from_webhook(): void
+    {
+        $user = User::factory()->create(['vatly_id' => 'customer_abc']);
+
+        $this->fakeGetChargeback($this->buildApiChargeback([
+            'id' => 'chargeback_abc123',
+            'customerId' => 'customer_abc',
+            'originalOrderId' => 'order_abc123',
+            'status' => 'pending',
+            'reason' => 'fraud',
+            'totalValue' => '99.00',
+            'subtotalValue' => '81.82',
+            'currency' => 'EUR',
+            'taxRates' => [
+                ['name' => 'VAT', 'percentage' => 21.0, 'taxablePercentage' => 100.0, 'amount' => '17.18'],
+            ],
+        ]));
+
+        $response = $this->postWebhookEvent('order.chargeback_received', 'order_abc123', 'order', [
+            'id' => 'chargeback_abc123',
+            'originalOrderId' => 'order_abc123',
+            'reason' => 'fraud',
+        ]);
+
+        $response->assertStatus(201);
+        $this->assertDatabaseHas('vatly_chargebacks', [
+            'vatly_id' => 'chargeback_abc123',
+            'original_order_id' => 'order_abc123',
+            'status' => 'pending',
+            'total' => 9900,
+            'currency' => 'EUR',
+            'reason' => 'fraud',
+            'owner_id' => $user->id,
+        ]);
+
+        $chargeback = Chargeback::where('vatly_id', 'chargeback_abc123')->firstOrFail();
+        $this->assertSame(8182, $chargeback->subtotal);
+        $this->assertSame(1718, $chargeback->tax_summary[0]['amount']);
+        $this->assertSame('fraud', $chargeback->getReason());
+        $this->assertFalse($chargeback->isReversed());
+    }
+
+    public function test_it_updates_a_chargeback_on_reversal_from_webhook(): void
+    {
+        $user = User::factory()->create(['vatly_id' => 'customer_abc']);
+
+        Chargeback::create([
+            'owner_type' => $user->getMorphClass(),
+            'owner_id' => $user->getKey(),
+            'vatly_id' => 'chargeback_rev1',
+            'customer_id' => 'customer_abc',
+            'original_order_id' => 'order_abc123',
+            'status' => 'pending',
+            'total' => 9900,
+            'subtotal' => 8182,
+            'currency' => 'EUR',
+            'reason' => 'fraud',
+        ]);
+
+        $this->fakeGetChargeback($this->buildApiChargeback([
+            'id' => 'chargeback_rev1',
+            'customerId' => 'customer_abc',
+            'originalOrderId' => 'order_abc123',
+            'status' => 'won',
+            'reason' => 'fraud',
+            'totalValue' => '99.00',
+            'subtotalValue' => '81.82',
+            'currency' => 'EUR',
+            'taxRates' => [
+                ['name' => 'VAT', 'percentage' => 21.0, 'taxablePercentage' => 100.0, 'amount' => '17.18'],
+            ],
+        ]));
+
+        $response = $this->postWebhookEvent('order.chargeback_reversed', 'order_abc123', 'order', [
+            'id' => 'chargeback_rev1',
+            'originalOrderId' => 'order_abc123',
+            'reason' => 'fraud',
+        ]);
+
+        $response->assertStatus(201);
+        $this->assertDatabaseCount('vatly_chargebacks', 1);
+
+        $chargeback = Chargeback::where('vatly_id', 'chargeback_rev1')->firstOrFail();
+        $this->assertSame('won', $chargeback->status);
+        $this->assertTrue($chargeback->isReversed());
     }
 }

--- a/tests/Models/OrderTest.php
+++ b/tests/Models/OrderTest.php
@@ -7,7 +7,9 @@ namespace Vatly\Laravel\Tests\Models;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Vatly\Fluent\Contracts\OrderInterface;
+use Vatly\Laravel\Models\Chargeback;
 use Vatly\Laravel\Models\Order;
+use Vatly\Laravel\Models\Refund;
 use Vatly\Laravel\Tests\BaseTestCase;
 
 class OrderTest extends BaseTestCase
@@ -104,5 +106,66 @@ class OrderTest extends BaseTestCase
         $order = new Order(['status' => 'pending']);
 
         $this->assertFalse($order->isPaid());
+    }
+
+    public function test_it_exposes_refunds_linked_on_the_vatly_order_id(): void
+    {
+        Order::create([
+            'vatly_id' => 'ord_refunds_1',
+            'status' => 'paid',
+            'total' => 9900,
+            'currency' => 'EUR',
+        ]);
+
+        Refund::create([
+            'vatly_id' => 'refund_1',
+            'original_order_id' => 'ord_refunds_1',
+            'status' => 'refunded',
+            'total' => 5000,
+            'currency' => 'EUR',
+        ]);
+        // A refund against a different order must not leak in.
+        Refund::create([
+            'vatly_id' => 'refund_other',
+            'original_order_id' => 'ord_other',
+            'status' => 'refunded',
+            'total' => 100,
+            'currency' => 'EUR',
+        ]);
+
+        $order = Order::where('vatly_id', 'ord_refunds_1')->firstOrFail();
+
+        $this->assertCount(1, $order->refunds);
+        $this->assertSame('refund_1', $order->refunds->first()->getVatlyId());
+    }
+
+    public function test_it_exposes_chargebacks_linked_on_the_vatly_order_id(): void
+    {
+        Order::create([
+            'vatly_id' => 'ord_cb_1',
+            'status' => 'paid',
+            'total' => 9900,
+            'currency' => 'EUR',
+        ]);
+
+        Chargeback::create([
+            'vatly_id' => 'chargeback_1',
+            'original_order_id' => 'ord_cb_1',
+            'status' => 'pending',
+            'total' => 9900,
+            'currency' => 'EUR',
+        ]);
+        Chargeback::create([
+            'vatly_id' => 'chargeback_other',
+            'original_order_id' => 'ord_other',
+            'status' => 'pending',
+            'total' => 100,
+            'currency' => 'EUR',
+        ]);
+
+        $order = Order::where('vatly_id', 'ord_cb_1')->firstOrFail();
+
+        $this->assertCount(1, $order->chargebacks);
+        $this->assertSame('chargeback_1', $order->chargebacks->first()->getVatlyId());
     }
 }

--- a/tests/Repositories/EloquentChargebackRepositoryTest.php
+++ b/tests/Repositories/EloquentChargebackRepositoryTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Laravel\Tests\Repositories;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Vatly\Fluent\Data\StoreChargebackData;
+use Vatly\Fluent\Data\UpdateChargebackData;
+use Vatly\Laravel\Models\Chargeback;
+use Vatly\Laravel\Repositories\EloquentChargebackRepository;
+use Vatly\Laravel\Tests\BaseTestCase;
+
+class EloquentChargebackRepositoryTest extends BaseTestCase
+{
+    use RefreshDatabase;
+
+    private EloquentChargebackRepository $repo;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->repo = $this->app->make(EloquentChargebackRepository::class);
+    }
+
+    public function test_store_persists_a_chargeback(): void
+    {
+        $chargeback = $this->repo->store(new StoreChargebackData(
+            vatlyId: 'chargeback_1',
+            customerId: 'customer_1',
+            status: 'pending',
+            total: 9900,
+            currency: 'EUR',
+            originalOrderId: 'order_1',
+            reason: 'fraud',
+            subtotal: 8182,
+        ));
+
+        $this->assertNotNull($chargeback);
+        $this->assertSame('chargeback_1', $chargeback->getVatlyId());
+        $this->assertSame('fraud', $chargeback->getReason());
+        $this->assertDatabaseHas('vatly_chargebacks', [
+            'vatly_id' => 'chargeback_1',
+            'original_order_id' => 'order_1',
+            'status' => 'pending',
+            'reason' => 'fraud',
+        ]);
+    }
+
+    public function test_find_by_vatly_id_returns_the_chargeback(): void
+    {
+        Chargeback::create([
+            'vatly_id' => 'chargeback_find',
+            'customer_id' => 'customer_1',
+            'original_order_id' => 'order_1',
+            'status' => 'pending',
+            'total' => 100,
+            'currency' => 'EUR',
+        ]);
+
+        $this->assertNotNull($this->repo->findByVatlyId('chargeback_find'));
+        $this->assertNull($this->repo->findByVatlyId('chargeback_missing'));
+    }
+
+    public function test_list_for_customer_returns_only_that_customers_chargebacks(): void
+    {
+        $this->makeChargeback('chargeback_a', 'customer_1', 'order_1');
+        $this->makeChargeback('chargeback_b', 'customer_1', 'order_2');
+        $this->makeChargeback('chargeback_c', 'customer_2', 'order_3');
+
+        $result = $this->repo->listForCustomer('customer_1');
+
+        $this->assertCount(2, $result);
+        $ids = array_map(fn ($c) => $c->getVatlyId(), $result);
+        $this->assertEqualsCanonicalizing(['chargeback_a', 'chargeback_b'], $ids);
+    }
+
+    public function test_list_for_order_returns_only_that_orders_chargebacks(): void
+    {
+        $this->makeChargeback('chargeback_a', 'customer_1', 'order_1');
+        $this->makeChargeback('chargeback_b', 'customer_2', 'order_1');
+        $this->makeChargeback('chargeback_c', 'customer_3', 'order_2');
+
+        $result = $this->repo->listForOrder('order_1');
+
+        $this->assertCount(2, $result);
+        $ids = array_map(fn ($c) => $c->getVatlyId(), $result);
+        $this->assertEqualsCanonicalizing(['chargeback_a', 'chargeback_b'], $ids);
+    }
+
+    public function test_update_flips_status_to_reversed(): void
+    {
+        $chargeback = $this->makeChargeback('chargeback_rev', 'customer_1', 'order_1');
+        $this->assertFalse($chargeback->isReversed());
+
+        $updated = $this->repo->update($chargeback, new UpdateChargebackData(status: 'won'));
+
+        $this->assertSame('won', $updated->getStatus());
+        $this->assertTrue($updated->isReversed());
+        $this->assertDatabaseHas('vatly_chargebacks', [
+            'vatly_id' => 'chargeback_rev',
+            'status' => 'won',
+        ]);
+    }
+
+    private function makeChargeback(string $vatlyId, string $customerId, string $originalOrderId): Chargeback
+    {
+        return Chargeback::create([
+            'vatly_id' => $vatlyId,
+            'customer_id' => $customerId,
+            'original_order_id' => $originalOrderId,
+            'status' => 'pending',
+            'total' => 9900,
+            'subtotal' => 8182,
+            'currency' => 'EUR',
+            'reason' => 'fraud',
+        ]);
+    }
+}

--- a/tests/Repositories/EloquentRefundRepositoryTest.php
+++ b/tests/Repositories/EloquentRefundRepositoryTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Laravel\Tests\Repositories;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Vatly\Laravel\Models\Refund;
+use Vatly\Laravel\Repositories\EloquentRefundRepository;
+use Vatly\Laravel\Tests\BaseTestCase;
+
+class EloquentRefundRepositoryTest extends BaseTestCase
+{
+    use RefreshDatabase;
+
+    private EloquentRefundRepository $repo;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->repo = $this->app->make(EloquentRefundRepository::class);
+    }
+
+    public function test_list_for_customer_returns_only_that_customers_refunds(): void
+    {
+        $this->makeRefund('refund_a', 'customer_1', 'order_1');
+        $this->makeRefund('refund_b', 'customer_1', 'order_2');
+        $this->makeRefund('refund_c', 'customer_2', 'order_3');
+
+        $result = $this->repo->listForCustomer('customer_1');
+
+        $this->assertCount(2, $result);
+        $ids = array_map(fn ($r) => $r->getVatlyId(), $result);
+        $this->assertEqualsCanonicalizing(['refund_a', 'refund_b'], $ids);
+    }
+
+    public function test_list_for_order_returns_only_that_orders_refunds(): void
+    {
+        $this->makeRefund('refund_a', 'customer_1', 'order_1');
+        $this->makeRefund('refund_b', 'customer_2', 'order_1');
+        $this->makeRefund('refund_c', 'customer_3', 'order_2');
+
+        $result = $this->repo->listForOrder('order_1');
+
+        $this->assertCount(2, $result);
+        $ids = array_map(fn ($r) => $r->getVatlyId(), $result);
+        $this->assertEqualsCanonicalizing(['refund_a', 'refund_b'], $ids);
+    }
+
+    private function makeRefund(string $vatlyId, string $customerId, string $originalOrderId): Refund
+    {
+        return Refund::create([
+            'vatly_id' => $vatlyId,
+            'customer_id' => $customerId,
+            'original_order_id' => $originalOrderId,
+            'status' => 'refunded',
+            'total' => 9900,
+            'subtotal' => 8182,
+            'currency' => 'EUR',
+        ]);
+    }
+}

--- a/tests/TestHelpers/PostsVatlyWebhooks.php
+++ b/tests/TestHelpers/PostsVatlyWebhooks.php
@@ -8,6 +8,7 @@ use Illuminate\Testing\TestResponse;
 use Mockery;
 use ReflectionClass;
 use Vatly\API\Exceptions\ApiException;
+use Vatly\API\Resources\Chargeback as ApiChargeback;
 use Vatly\API\Resources\Checkout as ApiCheckout;
 use Vatly\API\Resources\Order as ApiOrder;
 use Vatly\API\Resources\Refund as ApiRefund;
@@ -16,6 +17,7 @@ use Vatly\API\Types\Mandate;
 use Vatly\API\Types\Money;
 use Vatly\API\Types\TaxSummaryCollection;
 use Vatly\API\VatlyApiClient;
+use Vatly\Fluent\Actions\GetChargeback;
 use Vatly\Fluent\Actions\GetCheckout;
 use Vatly\Fluent\Actions\GetOrder;
 use Vatly\Fluent\Actions\GetRefund;
@@ -186,6 +188,26 @@ trait PostsVatlyWebhooks
         $this->app->forgetInstance(WebhookProcessor::class);
     }
 
+    /**
+     * Replace the cached `GetChargeback` action on the composition root so the
+     * `order.chargeback_*` webhook flow doesn't need a real API call. The
+     * factory enriches chargeback events via this action to carry the customer
+     * id, dispute status, and full tax breakdown.
+     */
+    protected function fakeGetChargeback(ApiChargeback $chargeback): void
+    {
+        $action = Mockery::mock(GetChargeback::class);
+        $action->shouldReceive('execute')->andReturn($chargeback);
+
+        $vatly = $this->app->make(Vatly::class);
+
+        $this->writeVatlyPrivate($vatly, 'getChargeback', $action);
+        $this->writeVatlyPrivate($vatly, 'webhookEventFactory', null);
+        $this->writeVatlyPrivate($vatly, 'webhookProcessor', null);
+
+        $this->app->forgetInstance(WebhookProcessor::class);
+    }
+
     protected function fakeGetSubscription(ApiSubscription $subscription): void
     {
         $this->fakeGetSubscriptions([
@@ -326,5 +348,43 @@ trait PostsVatlyWebhooks
         ));
 
         return $refund;
+    }
+
+    /**
+     * @param  array{
+     *   id: string,
+     *   customerId: string,
+     *   originalOrderId: string,
+     *   status: string,
+     *   totalValue: string,
+     *   subtotalValue: string,
+     *   currency: string,
+     *   reason?: string,
+     *   taxRates: array<int, array{name: string, percentage: float, taxablePercentage: float, amount: string}>,
+     * }  $data
+     */
+    protected function buildApiChargeback(array $data): ApiChargeback
+    {
+        $chargeback = new ApiChargeback(Mockery::mock(VatlyApiClient::class));
+        $chargeback->id = $data['id'];
+        $chargeback->customerId = $data['customerId'];
+        $chargeback->originalOrderId = $data['originalOrderId'];
+        $chargeback->status = $data['status'];
+        $chargeback->reason = $data['reason'] ?? '';
+        $chargeback->total = new Money($data['currency'], $data['totalValue']);
+        $chargeback->subtotal = new Money($data['currency'], $data['subtotalValue']);
+        $chargeback->taxSummary = new TaxSummaryCollection(array_map(
+            fn (array $rate) => [
+                'taxRate' => [
+                    'name' => $rate['name'],
+                    'percentage' => $rate['percentage'],
+                    'taxablePercentage' => $rate['taxablePercentage'],
+                ],
+                'amount' => ['currency' => $data['currency'], 'value' => $rate['amount']],
+            ],
+            $data['taxRates'],
+        ));
+
+        return $chargeback;
     }
 }


### PR DESCRIPTION
## What

Adopts `vatly/vatly-fluent-php` **`^0.8.0-alpha.13`**, handles its breaking change, and mirrors the refund integration for chargebacks — including the consumer-facing Eloquent relations.

Closes #37. Partially addresses #36 (refund read surface) — see that issue for the upstream-blocked remainder.

## Breaking change handled

alpha.13's `RefundReader` gained `listForCustomer()` and `listForOrder()`. `EloquentRefundRepository` now implements both (queried by `customer_id` / `original_order_id`) — without this the container can no longer satisfy `RefundRepositoryInterface`.

## New: chargeback persistence (mirror of refunds)

- **`Chargeback` model** implementing `ChargebackInterface`. `isReversed()` maps the `won` dispute status (funds returned to the merchant) — the API status enum is `pending/accepted/rejected/evidence_submitted/won/lost`, there is no literal `reversed`.
- **`EloquentChargebackRepository`** — `findByVatlyId` / `listForCustomer` / `listForOrder` / `store` (nullable, per `ChargebackWriter`) / `update`.
- **`create_vatly_chargebacks_table`** migration stub, published under the `vatly-migrations` tag.
- Bound `ChargebackRepositoryInterface` and passed it into the `Wiring` composition root in `VatlyServiceProvider`, so fluent registers `SyncChargebackOnStatusChange`. Enrichment via `GetChargeback` is wired automatically by fluent.

## Eloquent relations (consumer read surface)

- `Billable::refunds()` / `Billable::chargebacks()` — `MorphMany` owned by the billable.
- `Order::refunds()` / `Order::chargebacks()` — `HasMany` linked `original_order_id` → `vatly_id`.

`Subscription::refunds()` ("via renewal orders") is intentionally omitted: `vatly_orders` has no subscription-linkage column, so there's nothing to join on yet (noted on #36).

## Out of scope (not in alpha.13)

`OrderInterface::getSubtotal()`, `RefundReader::sumSubtotalsForOrder()`, and the `SyncOrderOnRefundChange` / `SyncOrderOnChargebackChange` order-status-sync reactions referenced by #36/#37 do **not** exist in fluent alpha.13 — order reversal progress is read live from the API, and the local order status stays terminal `paid`. The other alpha.13 additions (FakeVatly, trial helpers — #38) are independent and untouched here.

## Tests

- `order.chargeback_received` persistence + `order.chargeback_reversed` update webhook flows.
- Repository read-method coverage for both refunds and chargebacks.
- `Billable::refunds`/`chargebacks` and `Order::refunds`/`chargebacks` relation tests.
- `fakeGetChargeback` / `buildApiChargeback` test helpers; chargebacks table added to the test fixtures migration.

All green locally: **89 tests / 242 assertions**, PHPStan level 6 clean, Pint clean.

README updated (migration list, chargeback event docs, persistence note, relation examples). `phpstan.neon` gains the `MorphTo`-covariance ignore for the new model, matching the existing per-model entries.