### PR TITLE
feat(order): surface API-sourced reversal read helpers on Order model

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,14 @@ $user->chargebacks;                                     // all chargebacks (disp
 $order->refunds;                                        // refunds against this order
 $order->chargebacks;                                    // chargebacks against this order
 
+// Reversal progress — read live from the Vatly API (status stays `paid`).
+// Combines refunds and chargebacks: "did money come back, and how much".
+$order->isReversed();                                   // any subtotal reversed?
+$order->isPartiallyReversed();                          // reversed, but not in full
+$order->isFullyReversed();                              // full subtotal reversed
+$order->reversedSubtotal();                             // reversed subtotal, in cents
+$order->refundableSubtotal();                           // still-reversible subtotal, in cents
+
 // Static finders
 $user = User::findBillable('customer_xyz');             // ?User
 $user = User::findBillableOrFail('customer_xyz');       // User

--- a/src/Models/Order.php
+++ b/src/Models/Order.php
@@ -125,4 +125,54 @@ class Order extends Model implements OrderInterface
     {
         return app(Vatly::class)->order($this)->invoiceUrl();
     }
+
+    // Reversal read surface.
+    //
+    // The order's own `status` stays terminal `paid` even after a refund or
+    // chargeback; reversal progress is read live from the Vatly API rather than
+    // synthesized into a local status. These delegate to the framework-agnostic
+    // {@see OrderHandle} helpers (which memoize a single API fetch per call),
+    // so consumers can iterate the orders relation and ask each model directly.
+
+    /**
+     * Subtotal (net of tax, in integer cents) that has been reversed —
+     * refunded and/or charged back — per the live API order.
+     */
+    public function reversedSubtotal(): int
+    {
+        return app(Vatly::class)->order($this)->reversedSubtotal();
+    }
+
+    /**
+     * Subtotal (net of tax, in integer cents) still available to reverse per
+     * the live API order.
+     */
+    public function refundableSubtotal(): int
+    {
+        return app(Vatly::class)->order($this)->refundableSubtotal();
+    }
+
+    /**
+     * Whether any of the order's subtotal has been reversed.
+     */
+    public function isReversed(): bool
+    {
+        return app(Vatly::class)->order($this)->isReversed();
+    }
+
+    /**
+     * Whether the order is reversed but not in full.
+     */
+    public function isPartiallyReversed(): bool
+    {
+        return app(Vatly::class)->order($this)->isPartiallyReversed();
+    }
+
+    /**
+     * Whether the order's full subtotal has been reversed.
+     */
+    public function isFullyReversed(): bool
+    {
+        return app(Vatly::class)->order($this)->isFullyReversed();
+    }
 }

--- a/tests/Models/OrderTest.php
+++ b/tests/Models/OrderTest.php
@@ -6,7 +6,14 @@ namespace Vatly\Laravel\Tests\Models;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Mockery;
+use Vatly\API\Resources\Order as ApiOrder;
+use Vatly\API\Types\Money as ApiMoney;
+use Vatly\API\VatlyApiClient;
+use Vatly\Fluent\Actions\GetOrder;
 use Vatly\Fluent\Contracts\OrderInterface;
+use Vatly\Fluent\OrderHandle;
+use Vatly\Fluent\Vatly;
 use Vatly\Laravel\Models\Chargeback;
 use Vatly\Laravel\Models\Order;
 use Vatly\Laravel\Models\Refund;
@@ -167,5 +174,90 @@ class OrderTest extends BaseTestCase
 
         $this->assertCount(1, $order->chargebacks);
         $this->assertSame('chargeback_1', $order->chargebacks->first()->getVatlyId());
+    }
+
+    public function test_reversal_helpers_surface_a_partial_reversal_from_the_api_order(): void
+    {
+        $order = Order::create([
+            'vatly_id' => 'ord_partial_reversal',
+            'status' => 'paid',
+            'total' => 12100,
+            'subtotal' => 10000,
+            'currency' => 'EUR',
+        ]);
+
+        $this->fakeVatlyOrder($order, subtotal: '100.00', reversed: '40.00', refundable: '60.00');
+
+        // The local status stays terminal `paid` — reversal progress is read live.
+        $this->assertSame('paid', $order->getStatus());
+        $this->assertSame(4000, $order->reversedSubtotal());
+        $this->assertSame(6000, $order->refundableSubtotal());
+        $this->assertTrue($order->isReversed());
+        $this->assertTrue($order->isPartiallyReversed());
+        $this->assertFalse($order->isFullyReversed());
+    }
+
+    public function test_reversal_helpers_surface_a_full_reversal_from_the_api_order(): void
+    {
+        $order = Order::create([
+            'vatly_id' => 'ord_full_reversal',
+            'status' => 'paid',
+            'total' => 12100,
+            'subtotal' => 10000,
+            'currency' => 'EUR',
+        ]);
+
+        $this->fakeVatlyOrder($order, subtotal: '100.00', reversed: '100.00', refundable: '0.00');
+
+        $this->assertSame(10000, $order->reversedSubtotal());
+        $this->assertSame(0, $order->refundableSubtotal());
+        $this->assertTrue($order->isReversed());
+        $this->assertFalse($order->isPartiallyReversed());
+        $this->assertTrue($order->isFullyReversed());
+    }
+
+    public function test_reversal_helpers_report_no_reversal_for_an_untouched_order(): void
+    {
+        $order = Order::create([
+            'vatly_id' => 'ord_no_reversal',
+            'status' => 'paid',
+            'total' => 12100,
+            'subtotal' => 10000,
+            'currency' => 'EUR',
+        ]);
+
+        $this->fakeVatlyOrder($order, subtotal: '100.00', reversed: '0.00', refundable: '100.00');
+
+        $this->assertSame(0, $order->reversedSubtotal());
+        $this->assertSame(10000, $order->refundableSubtotal());
+        $this->assertFalse($order->isReversed());
+        $this->assertFalse($order->isPartiallyReversed());
+        $this->assertFalse($order->isFullyReversed());
+    }
+
+    /**
+     * Bind the {@see Vatly} facade so that resolving a handle for `$order`
+     * returns one backed by a canned API order with the given reversal figures,
+     * letting the model's reversal helpers run the real {@see OrderHandle} logic
+     * without hitting the network.
+     */
+    private function fakeVatlyOrder(Order $order, string $subtotal, string $reversed, string $refundable): void
+    {
+        $apiOrder = new ApiOrder(Mockery::mock(VatlyApiClient::class));
+        $apiOrder->subtotal = new ApiMoney('EUR', $subtotal);
+        $apiOrder->reversedSubtotal = new ApiMoney('EUR', $reversed);
+        $apiOrder->refundableSubtotal = new ApiMoney('EUR', $refundable);
+
+        $getOrder = Mockery::mock(GetOrder::class);
+        $getOrder->shouldReceive('execute')
+            ->with($order->getVatlyId())
+            ->andReturn($apiOrder);
+
+        $handle = new OrderHandle($order, $getOrder);
+
+        $vatly = Mockery::mock(Vatly::class);
+        $vatly->shouldReceive('order')->with($order)->andReturn($handle);
+
+        $this->app->instance(Vatly::class, $vatly);
     }
 }


### PR DESCRIPTION
Closes #36.

## Context — what #36 actually needs now

The ticket evolved a lot across its comments. Re-deriving it against the **released `vatly/vatly-fluent-php` v0.8.0-alpha.13** (which == fluent `main`, and contains [fluent #72](https://github.com/vatly/vatly-fluent-php/pull/72)) and `vatly-api-php` v0.1.0-alpha.14:

| Original ticket item | Outcome |
|---|---|
| `OrderInterface::getSubtotal()` | **Dropped upstream** — fluent pivoted to live-API reads; not in the contract |
| `sumSubtotalsForOrder()` + locked `FOR UPDATE` cumulative | **Dropped** — replaced by API-sourced `reversedSubtotal` |
| `SyncOrderOnRefundChange` (derive `refunded`/`partially_refunded`) | **Dropped** — order `status` stays terminal `paid`; `SyncRefundOnStatusChange` persists refund rows |
| `RefundReader::listForCustomer` / `listForOrder` | ✅ already implemented (#39) |
| `Billable::refunds()` / `Order::refunds()` | ✅ already implemented (#39) |
| **OrderHandle reversal helpers on `Order` model** | ✅ **this PR** |
| `Subscription::refunds()` via renewal orders | 🗑️ **De-scoped** — semantically unsound (see below) |

> Note: the issue's last comment marked some items "upstream-blocked / not in alpha.13". That was written against a **stale local vendor copy** — the released `alpha.13` tag does contain fluent #72. No cross-repo (fluent/api-php) changes were needed; everything was already shipped and released.

## This PR

Surfaces the reversal read surface on `Vatly\Laravel\Models\Order`, mirroring the existing `invoiceUrl()` delegation to the framework-agnostic `OrderHandle` (single memoized API fetch per call):

- `reversedSubtotal()` / `refundableSubtotal()` — integer cents
- `isReversed()` / `isPartiallyReversed()` / `isFullyReversed()`

These read the **live API order** — the local `status` deliberately stays `paid`. The helpers combine refunds *and* chargebacks ("did money come back, and how much").

## Tests
- `tests/Models/OrderTest.php`: partial / full / no-reversal cases, faking the `Vatly` facade so the **real `OrderHandle` logic** runs against a canned API order.
- Full suite green (92 tests), PHPStan clean, Pint clean.

## De-scoped: `Subscription::refunds()`
Not a "blocked" item — a relation that shouldn't exist. A refund targets an **order**, not a subscription; the order↔subscription link is many-to-many through order lines, and an order can mix multiple subscriptions + one-off products, so attributing a whole-order refund to one subscription is lossy. Consumers wanting subscription-scoped refunds should traverse `subscription → orders → $order->refunds`. Full rationale on #36.