### PR TITLE
docs: rename LocalSubscriptionCreated → SubscriptionWasCreatedFromWebhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Event::listen(OrderPaid::class, function (OrderPaid $event) {
 The webhook event DTOs live in `vatly-api-php` (alongside the rest of the API
 contracts) under the `Vatly\API\Webhooks\Events\` namespace, so a webhook field
 change is a single api-php release that flows through every integration. The
-one exception is `LocalSubscriptionCreated`, which is an internal fluent signal
+one exception is `SubscriptionWasCreatedFromWebhook`, which is an internal fluent signal
 (not a webhook payload) and stays under `Vatly\Fluent\Events\`.
 
 Events available:
@@ -199,7 +199,7 @@ Events available:
 - `Vatly\API\Webhooks\Events\SubscriptionCanceledWithGracePeriod`
 - `Vatly\API\Webhooks\Events\SubscriptionCancellationGracePeriodCompleted` — the grace period set at cancellation has elapsed; carries `customerId`, `subscriptionId`, `endsAt`. The local subscription's `ends_at` is stamped to the actual end (self-healing a missed `subscription.canceled_with_grace_period` webhook and correcting any drift); also dispatched so you can flip your own application-level "fully ended" state without polling.
 - `Vatly\API\Webhooks\Events\UnsupportedWebhookReceived`
-- `Vatly\Fluent\Events\LocalSubscriptionCreated` — internal fluent signal (not a webhook payload).
+- `Vatly\Fluent\Events\SubscriptionWasCreatedFromWebhook` — internal fluent signal (not a webhook payload).
 
 Refund webhooks (`refund.completed` / `refund.failed` / `refund.canceled`) are persisted to the `vatly_refunds` table via the bundled `Refund` model and `EloquentRefundRepository`. Chargeback webhooks (`order.chargeback_received` / `order.chargeback_reversed`) are persisted the same way to the `vatly_chargebacks` table via the bundled `Chargeback` model and `EloquentChargebackRepository` — Vatly's public order status doesn't change on a chargeback, so also wire your own listener if you need to suspend/reinstate access.
 

--- a/docs/Webhooks.md
+++ b/docs/Webhooks.md
@@ -26,7 +26,7 @@ Exclude the webhook route from CSRF verification. In Laravel 11+, this is typica
 
 ## Events
 
-When a webhook is received, the driver's `LaravelEventDispatcher` forwards the typed domain events straight onto Laravel's event bus, so you listen for the DTO classes directly. The webhook event DTOs live in `vatly-api-php` under the `Vatly\API\Webhooks\Events\` namespace (so a payload change is a single api-php release); the one exception is `LocalSubscriptionCreated`, an internal fluent signal under `Vatly\Fluent\Events\`:
+When a webhook is received, the driver's `LaravelEventDispatcher` forwards the typed domain events straight onto Laravel's event bus, so you listen for the DTO classes directly. The webhook event DTOs live in `vatly-api-php` under the `Vatly\API\Webhooks\Events\` namespace (so a payload change is a single api-php release); the one exception is `SubscriptionWasCreatedFromWebhook`, an internal fluent signal under `Vatly\Fluent\Events\`:
 
 | Event (`Vatly\API\Webhooks\Events\…`) | Dispatched when |
 | --- | --- |
@@ -46,15 +46,15 @@ When a webhook is received, the driver's `LaravelEventDispatcher` forwards the t
 | `CheckoutCanceled` | A `checkout.canceled` webhook is received — the customer abandoned the hosted checkout (cart-abandonment hook) |
 | `CheckoutExpired` | A `checkout.expired` webhook is received — the hosted checkout session timed out without completion |
 | `UnsupportedWebhookReceived` | A webhook arrives that has no typed mapping (carries the raw `eventName` / `object`) |
-| `LocalSubscriptionCreated` (in `Vatly\Fluent\Events\`) | A new local `Subscription` row was just created from a `subscription.started` webhook (application-level event; carries the stored `$subscription`) |
+| `SubscriptionWasCreatedFromWebhook` (in `Vatly\Fluent\Events\`) | A new local `Subscription` row was just created from a `subscription.started` webhook (application-level event; carries the stored `$subscription`) |
 
-Exactly one of the webhook events above is dispatched per incoming webhook (`UnsupportedWebhookReceived` is the fallback for unmapped events). `LocalSubscriptionCreated` fires additionally, from the subscription-sync reaction, only when a brand-new local row is created.
+Exactly one of the webhook events above is dispatched per incoming webhook (`UnsupportedWebhookReceived` is the fallback for unmapped events). `SubscriptionWasCreatedFromWebhook` fires additionally, from the subscription-sync reaction, only when a brand-new local row is created.
 
 ## Built-in reactions
 
 Before the event is dispatched, the package keeps your local tables in sync automatically via fluent's standard webhook *reactions*. These are wired by `WebhookProcessorFactory` inside the `Vatly` composition root — no registration needed on your side. They live under `Vatly\Fluent\Webhooks\Reactions\`:
 
-- **`SyncSubscriptionOnStarted`** -- On `SubscriptionStarted`, creates (or updates) the local `Subscription` row, then dispatches `LocalSubscriptionCreated` for newly-created rows.
+- **`SyncSubscriptionOnStarted`** -- On `SubscriptionStarted`, creates (or updates) the local `Subscription` row, then dispatches `SubscriptionWasCreatedFromWebhook` for newly-created rows.
 - **`CancelSubscriptionOnCanceled`** -- On `SubscriptionCanceledImmediately` / `SubscriptionCanceledWithGracePeriod`, sets the local subscription's `ends_at`.
 - **`StoreOrderOnPaid`** -- On `OrderPaid`, stores (or updates) the local `Order` row.
 - **`StoreOrderOnPaymentFailed`** -- On `PaymentFailed`, stores (or updates) the local `Order` row, mirroring the upstream order status verbatim.


### PR DESCRIPTION
## What

Docs-only follow-up to the fluent rename (vatly/vatly-fluent-php#84). The internal fluent event `Vatly\Fluent\Events\LocalSubscriptionCreated` is renamed to `Vatly\Fluent\Events\SubscriptionWasCreatedFromWebhook` (same namespace). This repo only references it in prose.

## Changes

- `docs/Webhooks.md` — events table row + two prose mentions + the `SyncSubscriptionOnStarted` reaction bullet.
- `README.md` — the `Vatly\Fluent\Events\…` bullet + the "internal fluent signal" exception line.

## Verification

- No PHP code references the event (docs-only).
- Repo-wide grep for `LocalSubscriptionCreated` — zero remaining.

> Merge alongside / after the fluent PR.