### PR TITLE
feat: adopt order.payment_failed rename + new OrderWasCreatedFromWebhook/WebhookSetupReceived events

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,15 +181,16 @@ Event::listen(OrderPaid::class, function (OrderPaid $event) {
 The webhook event DTOs live in `vatly-api-php` (alongside the rest of the API
 contracts) under the `Vatly\API\Webhooks\Events\` namespace, so a webhook field
 change is a single api-php release that flows through every integration. The
-one exception is `SubscriptionWasCreatedFromWebhook`, which is an internal fluent signal
-(not a webhook payload) and stays under `Vatly\Fluent\Events\`.
+exceptions are `SubscriptionWasCreatedFromWebhook` and `OrderWasCreatedFromWebhook`,
+which are internal fluent signals (not webhook payloads) and stay under
+`Vatly\Fluent\Events\`.
 
 Events available:
 
 - `Vatly\API\Webhooks\Events\OrderPaid` — carries `total`, `subtotal`, `taxSummary` (full per-rate breakdown), `currency`, `invoiceNumber`, `paymentMethod`. Materialize local invoices without an extra API call.
 - `Vatly\API\Webhooks\Events\OrderCanceled` — the local order's status is mirrored to `canceled`.
 - `Vatly\API\Webhooks\Events\OrderChargebackReceived` / `OrderChargebackReversed` — dispute signals carrying the affected `orderId`, enriched with `customerId`, dispute `status`, totals and `taxSummary`; persisted to `vatly_chargebacks` (see below). Also react to suspend/reinstate access — a chargeback never mutates the local order row.
-- `Vatly\API\Webhooks\Events\PaymentFailed` — same enriched order shape as `OrderPaid`; typically the start of dunning.
+- `Vatly\API\Webhooks\Events\OrderPaymentFailed` — same enriched order shape as `OrderPaid`; typically the start of dunning.
 - `Vatly\API\Webhooks\Events\CheckoutPaid` / `CheckoutFailed` / `CheckoutCanceled` / `CheckoutExpired` — hosted-checkout lifecycle signals carrying `checkoutId`, nullable `customerId` / `orderId`, `status` and `metadata`. Dispatched straight from the payload (no enrichment GET, no local row); `CheckoutPaid` fires before `OrderPaid` so you can drive in-app receipt/analytics UI, while the others feed retry / cart-abandonment flows.
 - `Vatly\API\Webhooks\Events\RefundCompleted` / `RefundFailed` / `RefundCanceled` — each with full `taxSummary`; persisted to `vatly_refunds` (see below).
 - `Vatly\API\Webhooks\Events\SubscriptionStarted`
@@ -198,8 +199,10 @@ Events available:
 - `Vatly\API\Webhooks\Events\SubscriptionCanceledImmediately`
 - `Vatly\API\Webhooks\Events\SubscriptionCanceledWithGracePeriod`
 - `Vatly\API\Webhooks\Events\SubscriptionCancellationGracePeriodCompleted` — the grace period set at cancellation has elapsed; carries `customerId`, `subscriptionId`, `endsAt`. The local subscription's `ends_at` is stamped to the actual end (self-healing a missed `subscription.canceled_with_grace_period` webhook and correcting any drift); also dispatched so you can flip your own application-level "fully ended" state without polling.
+- `Vatly\API\Webhooks\Events\WebhookSetupReceived` — a `webhook.setup` endpoint-verification call; no resource to enrich and no local row to touch, just acknowledge with a `2xx`.
 - `Vatly\API\Webhooks\Events\UnsupportedWebhookReceived`
 - `Vatly\Fluent\Events\SubscriptionWasCreatedFromWebhook` — internal fluent signal (not a webhook payload).
+- `Vatly\Fluent\Events\OrderWasCreatedFromWebhook` — the order analogue of `SubscriptionWasCreatedFromWebhook`: an internal fluent signal that fires once when a brand-new local `Order` row is created from an `order.paid` webhook. A clean hook for receipts / fulfillment.
 
 Refund webhooks (`refund.completed` / `refund.failed` / `refund.canceled`) are persisted to the `vatly_refunds` table via the bundled `Refund` model and `EloquentRefundRepository`. Chargeback webhooks (`order.chargeback_received` / `order.chargeback_reversed`) are persisted the same way to the `vatly_chargebacks` table via the bundled `Chargeback` model and `EloquentChargebackRepository` — Vatly's public order status doesn't change on a chargeback, so also wire your own listener if you need to suspend/reinstate access.
 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "illuminate/http": "^12.0|^13.0",
         "illuminate/routing": "^12.0|^13.0",
         "illuminate/support": "^12.0|^13.0",
-        "vatly/vatly-fluent-php": "^0.8.0-alpha.15"
+        "vatly/vatly-fluent-php": "^0.8.0-alpha.17"
     },
     "require-dev": {
         "larastan/larastan": "^3.9",

--- a/docs/Webhooks.md
+++ b/docs/Webhooks.md
@@ -26,7 +26,7 @@ Exclude the webhook route from CSRF verification. In Laravel 11+, this is typica
 
 ## Events
 
-When a webhook is received, the driver's `LaravelEventDispatcher` forwards the typed domain events straight onto Laravel's event bus, so you listen for the DTO classes directly. The webhook event DTOs live in `vatly-api-php` under the `Vatly\API\Webhooks\Events\` namespace (so a payload change is a single api-php release); the one exception is `SubscriptionWasCreatedFromWebhook`, an internal fluent signal under `Vatly\Fluent\Events\`:
+When a webhook is received, the driver's `LaravelEventDispatcher` forwards the typed domain events straight onto Laravel's event bus, so you listen for the DTO classes directly. The webhook event DTOs live in `vatly-api-php` under the `Vatly\API\Webhooks\Events\` namespace (so a payload change is a single api-php release); the exceptions are `SubscriptionWasCreatedFromWebhook` and `OrderWasCreatedFromWebhook`, internal fluent signals under `Vatly\Fluent\Events\`:
 
 | Event (`Vatly\API\Webhooks\Events\…`) | Dispatched when |
 | --- | --- |
@@ -38,17 +38,19 @@ When a webhook is received, the driver's `LaravelEventDispatcher` forwards the t
 | `SubscriptionCancellationGracePeriodCompleted` | A `subscription.cancellation_grace_period_completed` webhook is received — the grace period stamped by the cancellation has now elapsed (carries `customerId`, `subscriptionId`, `endsAt`) |
 | `OrderPaid` | An `order.paid` webhook is received (enriched with the full tax breakdown) |
 | `OrderCanceled` | An `order.canceled` webhook is received — the local order status is mirrored to `canceled` |
-| `PaymentFailed` | A `payment.failed` webhook is received — typically the start of dunning (enriched with the full tax breakdown) |
+| `OrderPaymentFailed` | An `order.payment_failed` webhook is received — typically the start of dunning (enriched with the full tax breakdown) |
 | `OrderChargebackReceived` / `OrderChargebackReversed` | An `order.chargeback_received` / `order.chargeback_reversed` webhook is received — enriched with `customerId`, dispute `status`, totals and `taxSummary`; persisted to `vatly_chargebacks` |
 | `RefundCompleted` / `RefundFailed` / `RefundCanceled` | A `refund.completed` / `refund.failed` / `refund.canceled` webhook is received — each carries the full `taxSummary`; persisted to `vatly_refunds` |
 | `CheckoutPaid` | A `checkout.paid` webhook is received — the hosted checkout was paid (fires before `order.paid`'s enrichment GET; carries `checkoutId`, nullable `customerId` / `orderId`, `status`, `metadata`) |
 | `CheckoutFailed` | A `checkout.failed` webhook is received — the hosted checkout's payment failed (route into a retry flow) |
 | `CheckoutCanceled` | A `checkout.canceled` webhook is received — the customer abandoned the hosted checkout (cart-abandonment hook) |
 | `CheckoutExpired` | A `checkout.expired` webhook is received — the hosted checkout session timed out without completion |
+| `WebhookSetupReceived` | A `webhook.setup` verification call is received — Vatly confirms a newly registered (or re-pointed) endpoint is reachable. There's no resource to enrich and no local row to touch; just acknowledge with a `2xx`. Carries only the webhook envelope (`eventName` / `object`) |
 | `UnsupportedWebhookReceived` | A webhook arrives that has no typed mapping (carries the raw `eventName` / `object`) |
 | `SubscriptionWasCreatedFromWebhook` (in `Vatly\Fluent\Events\`) | A new local `Subscription` row was just created from a `subscription.started` webhook (application-level event; carries the stored `$subscription`) |
+| `OrderWasCreatedFromWebhook` (in `Vatly\Fluent\Events\`) | The order analogue of `SubscriptionWasCreatedFromWebhook`: a new local `Order` row was just created from an `order.paid` webhook (fires once on a brand-new order; carries the stored `$order`). A clean hook for receipts / fulfillment |
 
-Exactly one of the webhook events above is dispatched per incoming webhook (`UnsupportedWebhookReceived` is the fallback for unmapped events). `SubscriptionWasCreatedFromWebhook` fires additionally, from the subscription-sync reaction, only when a brand-new local row is created.
+Exactly one of the webhook events above is dispatched per incoming webhook (`UnsupportedWebhookReceived` is the fallback for unmapped events). `SubscriptionWasCreatedFromWebhook` and `OrderWasCreatedFromWebhook` fire additionally, from the subscription- and order-sync reactions, only when a brand-new local row is created.
 
 ## Built-in reactions
 
@@ -56,8 +58,8 @@ Before the event is dispatched, the package keeps your local tables in sync auto
 
 - **`SyncSubscriptionOnStarted`** -- On `SubscriptionStarted`, creates (or updates) the local `Subscription` row, then dispatches `SubscriptionWasCreatedFromWebhook` for newly-created rows.
 - **`CancelSubscriptionOnCanceled`** -- On `SubscriptionCanceledImmediately` / `SubscriptionCanceledWithGracePeriod`, sets the local subscription's `ends_at`.
-- **`StoreOrderOnPaid`** -- On `OrderPaid`, stores (or updates) the local `Order` row.
-- **`StoreOrderOnPaymentFailed`** -- On `PaymentFailed`, stores (or updates) the local `Order` row, mirroring the upstream order status verbatim.
+- **`StoreOrderOnPaid`** -- On `OrderPaid`, stores (or updates) the local `Order` row, then dispatches `OrderWasCreatedFromWebhook` for newly-created rows.
+- **`StoreOrderOnPaymentFailed`** -- On `OrderPaymentFailed`, stores (or updates) the local `Order` row, mirroring the upstream order status verbatim.
 - **`EndSubscriptionOnGracePeriodCompleted`** -- On `SubscriptionCancellationGracePeriodCompleted`, stamps the actual `ends_at` onto the local subscription. Usually an idempotent re-write of what `CancelSubscriptionOnCanceled` already stored, but it self-heals a missed/out-of-order `subscription.canceled_with_grace_period` webhook (which would otherwise leave `ends_at` null and the subscription looking active forever) and corrects any drift between the scheduled and actual end.
 
 The checkout events (`CheckoutPaid` / `CheckoutFailed` / `CheckoutCanceled` / `CheckoutExpired`) ship no built-in reaction — they touch no local table. The checkout payloads carry the full Checkout resource (so they're dispatched without an enrichment GET), and there is no local checkout entity to keep in sync. Listen for them directly to drive receipt/retry/cart-abandonment UI or to flip your own application-level state. `SubscriptionCancellationGracePeriodCompleted` is likewise dispatched (on top of the reaction above) for consumers that want to flip their own application-level "fully ended" status.
@@ -82,7 +84,7 @@ Event::listen(SubscriptionStarted::class, function (SubscriptionStarted $event) 
 });
 ```
 
-Order events (`OrderPaid` / `PaymentFailed`) carry the full, API-enriched order — including the tax breakdown — so you can materialize an invoice without a follow-up API call:
+Order events (`OrderPaid` / `OrderPaymentFailed`) carry the full, API-enriched order — including the tax breakdown — so you can materialize an invoice without a follow-up API call:
 
 ```php
 use Illuminate\Support\Facades\Event;

--- a/tests/Http/Controllers/VatlyInboundWebhookControllerTest.php
+++ b/tests/Http/Controllers/VatlyInboundWebhookControllerTest.php
@@ -14,11 +14,13 @@ use Vatly\API\Webhooks\Events\CheckoutFailed;
 use Vatly\API\Webhooks\Events\CheckoutPaid;
 use Vatly\API\Webhooks\Events\OrderChargebackReceived;
 use Vatly\API\Webhooks\Events\OrderChargebackReversed;
-use Vatly\API\Webhooks\Events\PaymentFailed;
+use Vatly\API\Webhooks\Events\OrderPaymentFailed;
 use Vatly\API\Webhooks\Events\RefundCanceled;
 use Vatly\API\Webhooks\Events\RefundCompleted;
 use Vatly\API\Webhooks\Events\RefundFailed;
 use Vatly\API\Webhooks\Events\SubscriptionCancellationGracePeriodCompleted;
+use Vatly\API\Webhooks\Events\WebhookSetupReceived;
+use Vatly\Fluent\Events\OrderWasCreatedFromWebhook;
 use Vatly\Laravel\Models\Chargeback;
 use Vatly\Laravel\Models\Order;
 use Vatly\Laravel\Models\Refund;
@@ -285,7 +287,7 @@ class VatlyInboundWebhookControllerTest extends BaseTestCase
         $apiOrder->status = 'pending';
         $this->fakeGetOrder($apiOrder);
 
-        $response = $this->postWebhookEvent('payment.failed', 'order_failed_1', 'order', [
+        $response = $this->postWebhookEvent('order.payment_failed', 'order_failed_1', 'order', [
             'customerId' => 'customer_abc',
             'total' => ['currency' => 'EUR', 'value' => '99.00'],
             'invoiceNumber' => 'INV-009',
@@ -304,7 +306,7 @@ class VatlyInboundWebhookControllerTest extends BaseTestCase
 
     public function test_it_dispatches_the_payment_failed_event_from_webhook(): void
     {
-        Event::fake([PaymentFailed::class]);
+        Event::fake([OrderPaymentFailed::class]);
 
         User::factory()->create(['vatly_id' => 'customer_abc']);
 
@@ -323,15 +325,67 @@ class VatlyInboundWebhookControllerTest extends BaseTestCase
         $apiOrder->status = 'pending';
         $this->fakeGetOrder($apiOrder);
 
-        $this->postWebhookEvent('payment.failed', 'order_failed_2', 'order', [
+        $this->postWebhookEvent('order.payment_failed', 'order_failed_2', 'order', [
             'customerId' => 'customer_abc',
             'total' => ['currency' => 'EUR', 'value' => '99.00'],
         ])->assertStatus(201);
 
         Event::assertDispatched(
-            PaymentFailed::class,
-            fn (PaymentFailed $event): bool => $event->orderId === 'order_failed_2'
+            OrderPaymentFailed::class,
+            fn (OrderPaymentFailed $event): bool => $event->orderId === 'order_failed_2'
                 && $event->customerId === 'customer_abc',
+        );
+    }
+
+    public function test_it_dispatches_the_order_was_created_from_webhook_event(): void
+    {
+        // The order analogue of SubscriptionWasCreatedFromWebhook: a driver-side
+        // signal that fires once, from the order-sync reaction, when a brand-new
+        // local Order row is created from an order.paid webhook.
+        Event::fake([OrderWasCreatedFromWebhook::class]);
+
+        User::factory()->create(['vatly_id' => 'customer_abc']);
+
+        $this->fakeGetOrder($this->buildApiOrder([
+            'id' => 'order_created_evt',
+            'customerId' => 'customer_abc',
+            'totalValue' => '99.00',
+            'subtotalValue' => '81.82',
+            'currency' => 'EUR',
+            'invoiceNumber' => 'INV-100',
+            'paymentMethod' => 'card',
+            'taxRates' => [
+                ['name' => 'VAT', 'percentage' => 21.0, 'taxablePercentage' => 100.0, 'amount' => '17.18'],
+            ],
+        ]));
+
+        $this->postWebhookEvent('order.paid', 'order_created_evt', 'order', [
+            'customerId' => 'customer_abc',
+            'total' => ['currency' => 'EUR', 'value' => '99.00'],
+            'invoiceNumber' => 'INV-100',
+            'paymentMethod' => 'card',
+        ])->assertStatus(201);
+
+        Event::assertDispatched(
+            OrderWasCreatedFromWebhook::class,
+            fn (OrderWasCreatedFromWebhook $event): bool => $event->order->getVatlyId() === 'order_created_evt',
+        );
+    }
+
+    public function test_it_dispatches_the_webhook_setup_received_event(): void
+    {
+        Event::fake([WebhookSetupReceived::class]);
+
+        $this->postWebhookEvent('webhook.setup', 'webhook_endpoint_1', 'webhook', [
+            'url' => 'https://example.test/webhooks/vatly',
+        ])->assertStatus(201);
+
+        $this->assertDatabaseCount('vatly_webhook_calls', 1);
+
+        Event::assertDispatched(
+            WebhookSetupReceived::class,
+            fn (WebhookSetupReceived $event): bool => $event->entityType === 'webhook'
+                && $event->eventName === 'webhook.setup',
         );
     }
 


### PR DESCRIPTION
## Summary

Adopts vatly-fluent-php **v0.8.0-alpha.17** + vatly-api-php **v0.1.0-alpha.17** (Wave R3).

- **Bump**: `vatly/vatly-fluent-php` → `^0.8.0-alpha.17` (pulls `vatly-api-php` `v0.1.0-alpha.17`).
- **Rename**: webhook event `PaymentFailed` → `OrderPaymentFailed` (`Vatly\API\Webhooks\Events\OrderPaymentFailed`, wire `order.payment_failed`). Updated the import, `Event::fake([...])`, `assertDispatched`, type-hints, and the stored-order test's wire name in `VatlyInboundWebhookControllerTest`; updated `docs/Webhooks.md` + `README.md` references.
- **Two new events documented**:
  - `Vatly\Fluent\Events\OrderWasCreatedFromWebhook` — driver-side signal, the order analogue of `SubscriptionWasCreatedFromWebhook`; fires once when a brand-new local `Order` row is created from an `order.paid` webhook (clean hook for receipts/fulfillment). Dispatched by the `StoreOrderOnPaid` reaction.
  - `Vatly\API\Webhooks\Events\WebhookSetupReceived` — `webhook.setup` endpoint-verification call; no resource to enrich and no local row to touch, just acknowledge with a `2xx`.
- **Test coverage**: added dispatch tests `test_it_dispatches_the_order_was_created_from_webhook_event` (order.paid → new local order) and `test_it_dispatches_the_webhook_setup_received_event` (webhook.setup payload).

## Gates

- `vendor/bin/phpunit` — 112 tests, 307 assertions, green
- `vendor/bin/phpstan analyse --memory-limit=1G` — no errors
- `vendor/bin/pint --test` — passed

No tag (alpha release handled separately).