### PR TITLE
feat: adopt Money-typed webhook events (api-php/fluent alpha.18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,9 @@ Vatly events are dispatched on Laravel's event bus — register listeners the us
 use Vatly\API\Webhooks\Events\OrderPaid;
 
 Event::listen(OrderPaid::class, function (OrderPaid $event) {
+    $event->total->toCents();   // 9900 — minor units
+    $event->total->currency;    // "EUR"
+
     // send receipt, etc.
 });
 ```
@@ -187,7 +190,7 @@ which are internal fluent signals (not webhook payloads) and stay under
 
 Events available:
 
-- `Vatly\API\Webhooks\Events\OrderPaid` — carries `total`, `subtotal`, `taxSummary` (full per-rate breakdown), `currency`, `invoiceNumber`, `paymentMethod`. Materialize local invoices without an extra API call.
+- `Vatly\API\Webhooks\Events\OrderPaid` — carries `total`, `subtotal` (both `Vatly\API\Types\Money`), `taxSummary` (full per-rate breakdown), `invoiceNumber`, `paymentMethod`. Read the currency via `$event->total->currency` and minor units via `$event->total->toCents()` (there's no standalone `currency` field). Materialize local invoices without an extra API call.
 - `Vatly\API\Webhooks\Events\OrderCanceled` — the local order's status is mirrored to `canceled`.
 - `Vatly\API\Webhooks\Events\OrderChargebackReceived` / `OrderChargebackReversed` — dispute signals carrying the affected `orderId`, enriched with `customerId`, dispute `status`, totals and `taxSummary`; persisted to `vatly_chargebacks` (see below). Also react to suspend/reinstate access — a chargeback never mutates the local order row.
 - `Vatly\API\Webhooks\Events\OrderPaymentFailed` — same enriched order shape as `OrderPaid`; typically the start of dunning.
@@ -278,7 +281,7 @@ See [`tests/Http/Controllers/VatlyInboundWebhookControllerTest.php`](tests/Http/
 
 The ecosystem splits into three layers:
 
-- [`vatly/vatly-api-php`](https://github.com/Vatly/vatly-api-php) owns the API client and every wire contract — REST resources, value types (`Money`, `TaxSummaryCollection`), the `Vatly\API\Data\OrderLineData` DTO, and the webhook event DTOs under `Vatly\API\Webhooks\Events\`. A webhook-payload change is a single api-php release.
+- [`vatly/vatly-api-php`](https://github.com/Vatly/vatly-api-php) owns the API client and every wire contract — REST resources, value types (`Money`, `TaxSummaryCollection`), the `Vatly\API\Types\OrderLineData` DTO, and the webhook event DTOs under `Vatly\API\Webhooks\Events\`. A webhook-payload change is a single api-php release.
 - [`vatly/vatly-fluent-php`](https://github.com/Vatly/vatly-fluent-php) is the framework-agnostic core: the contracts, composition root (`Vatly`), webhook pipeline (factory / processor / reactions that consume the api-php event DTOs), and the operation wrappers (`Vatly\Fluent\SubscriptionHandle`, `Vatly\Fluent\OrderHandle`).
 - This package is the thin Laravel driver on top of fluent. It supplies:
 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "illuminate/http": "^12.0|^13.0",
         "illuminate/routing": "^12.0|^13.0",
         "illuminate/support": "^12.0|^13.0",
-        "vatly/vatly-fluent-php": "^0.8.0-alpha.17"
+        "vatly/vatly-fluent-php": "^0.8.0-alpha.18"
     },
     "require-dev": {
         "larastan/larastan": "^3.9",

--- a/docs/Webhooks.md
+++ b/docs/Webhooks.md
@@ -50,6 +50,8 @@ When a webhook is received, the driver's `LaravelEventDispatcher` forwards the t
 | `SubscriptionWasCreatedFromWebhook` (in `Vatly\Fluent\Events\`) | A new local `Subscription` row was just created from a `subscription.started` webhook (application-level event; carries the stored `$subscription`) |
 | `OrderWasCreatedFromWebhook` (in `Vatly\Fluent\Events\`) | The order analogue of `SubscriptionWasCreatedFromWebhook`: a new local `Order` row was just created from an `order.paid` webhook (fires once on a brand-new order; carries the stored `$order`). A clean hook for receipts / fulfillment |
 
+**Money fields.** On the order and refund events (`OrderPaid`, `OrderPaymentFailed`, `RefundCompleted` / `RefundFailed` / `RefundCanceled`), `total` and `subtotal` are non-null `Vatly\API\Types\Money` value objects (a decimal-string `value` plus a `currency`); read the currency via `$event->total->currency` and minor units via `$event->total->toCents()`. These events no longer carry a standalone `currency` field. The chargeback events (`OrderChargebackReceived` / `OrderChargebackReversed`) carry nullable `?Money` `total` / `subtotal` and **keep** their standalone `currency` field.
+
 Exactly one of the webhook events above is dispatched per incoming webhook (`UnsupportedWebhookReceived` is the fallback for unmapped events). `SubscriptionWasCreatedFromWebhook` and `OrderWasCreatedFromWebhook` fire additionally, from the subscription- and order-sync reactions, only when a brand-new local row is created.
 
 ## Built-in reactions
@@ -94,9 +96,11 @@ Event::listen(OrderPaid::class, function (OrderPaid $event) {
     // $event->orderId
     // $event->customerId
     // $event->status
-    // $event->total      // minor units (cents)
-    // $event->subtotal   // minor units (cents)
-    // $event->currency
+    // $event->total              // Vatly\API\Types\Money
+    // $event->subtotal           // Vatly\API\Types\Money
+    // $event->total->currency    // e.g. "EUR"
+    // $event->total->value       // decimal string, e.g. "99.00"
+    // $event->total->toCents()   // minor units (cents), e.g. 9900
     // $event->taxSummary
     // $event->invoiceNumber
     // $event->paymentMethod

--- a/src/Repositories/EloquentOrderLineRepository.php
+++ b/src/Repositories/EloquentOrderLineRepository.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Vatly\Laravel\Repositories;
 
-use Vatly\API\Data\OrderLineData;
+use Vatly\API\Types\OrderLineData;
 use Vatly\Fluent\Contracts\OrderLineInterface;
 use Vatly\Fluent\Contracts\OrderLineRepositoryInterface;
 use Vatly\Laravel\Models\OrderLine;
@@ -40,9 +40,9 @@ class EloquentOrderLineRepository implements OrderLineRepositoryInterface
             'vatly_id' => $data->vatlyId,
             'description' => $data->description,
             'quantity' => $data->quantity,
-            'base_price' => $data->basePrice,
-            'total' => $data->total,
-            'subtotal' => $data->subtotal,
+            'base_price' => $data->basePrice->toCents(),
+            'total' => $data->total->toCents(),
+            'subtotal' => $data->subtotal->toCents(),
             'tax_summary' => $this->serializeTaxSummary($data->taxSummary),
             'product_type' => $data->productType,
             'product_id' => $data->productId,

--- a/tests/Http/Controllers/VatlyInboundWebhookControllerTest.php
+++ b/tests/Http/Controllers/VatlyInboundWebhookControllerTest.php
@@ -649,7 +649,7 @@ class VatlyInboundWebhookControllerTest extends BaseTestCase
                 && $event->customerId === 'customer_abc'
                 && $event->originalOrderId === 'order_abc123'
                 && $event->status === 'refunded'
-                && $event->total === 9900,
+                && $event->total->toCents() === 9900,
         );
     }
 

--- a/tests/Models/OrderTest.php
+++ b/tests/Models/OrderTest.php
@@ -7,9 +7,9 @@ namespace Vatly\Laravel\Tests\Models;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Mockery;
-use Vatly\API\Data\OrderLineData;
 use Vatly\API\Resources\Order as ApiOrder;
 use Vatly\API\Types\Money as ApiMoney;
+use Vatly\API\Types\OrderLineData;
 use Vatly\API\VatlyApiClient;
 use Vatly\Fluent\Actions\GetOrder;
 use Vatly\Fluent\Contracts\OrderInterface;
@@ -231,9 +231,9 @@ class OrderTest extends BaseTestCase
                     vatlyId: 'order_item_x',
                     description: 'Pro plan — monthly',
                     quantity: 1,
-                    basePrice: 9900,
-                    total: 9900,
-                    subtotal: 8182,
+                    basePrice: new ApiMoney('EUR', '99.00'),
+                    total: new ApiMoney('EUR', '99.00'),
+                    subtotal: new ApiMoney('EUR', '81.82'),
                     productType: 'subscription',
                     productId: 'subscription_42',
                 ),

--- a/tests/Repositories/EloquentOrderLineRepositoryTest.php
+++ b/tests/Repositories/EloquentOrderLineRepositoryTest.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 namespace Vatly\Laravel\Tests\Repositories;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Vatly\API\Data\OrderLineData;
+use Vatly\API\Types\Money;
+use Vatly\API\Types\OrderLineData;
 use Vatly\Laravel\Models\OrderLine;
 use Vatly\Laravel\Repositories\EloquentOrderLineRepository;
 use Vatly\Laravel\Tests\BaseTestCase;
@@ -62,9 +63,9 @@ class EloquentOrderLineRepositoryTest extends BaseTestCase
                 vatlyId: 'order_item_store',
                 description: 'Pro plan — monthly',
                 quantity: 1,
-                basePrice: 9900,
-                total: 9900,
-                subtotal: 8182,
+                basePrice: new Money('EUR', '99.00'),
+                total: new Money('EUR', '99.00'),
+                subtotal: new Money('EUR', '81.82'),
                 taxSummary: null,
                 productType: 'subscription',
                 productId: 'subscription_123',
@@ -82,6 +83,9 @@ class EloquentOrderLineRepositoryTest extends BaseTestCase
             'order_vatly_id' => 'order_store',
             'product_type' => 'subscription',
             'product_id' => 'subscription_123',
+            'base_price' => 9900,
+            'total' => 9900,
+            'subtotal' => 8182,
         ]);
     }
 


### PR DESCRIPTION
## What

Adopts the Money-typed webhook event surface from **vatly-fluent-php v0.8.0-alpha.18** + **vatly-api-php v0.1.0-alpha.18**.

Upstream, webhook event money fields became `Vatly\API\Types\Money` (decimal-string `value` + `currency`) instead of int cents:
- Order / Refund / `OrderPaymentFailed` events: `total`/`subtotal` are non-null `Money`; the standalone `currency` field is **removed** (read it via `$event->total->currency`).
- Chargeback events: `total`/`subtotal` are `?Money`; standalone `currency` field is **kept**.
- `Vatly\API\Types\OrderLineData` (moved from `Vatly\API\Data\`); `basePrice`/`total`/`subtotal` are now `Money`.

fluent's `Store*Data`/`Update*Data` are unchanged (still int cents + currency string) and the reactions still flatten, so the Eloquent repos that persist from `Store*Data` need no change.

## Changes

- **composer**: bump `vatly/vatly-fluent-php` → `^0.8.0-alpha.18`; locked fluent `v0.8.0-alpha.18`, api-php `v0.1.0-alpha.18`.
- **Order-line persistence** (`EloquentOrderLineRepository`): import moved to `Vatly\API\Types\OrderLineData`; persists `basePrice`/`total`/`subtotal` via `->toCents()`.
- **Tests**: `OrderTest` + `EloquentOrderLineRepositoryTest` construct `OrderLineData` money fields as `Money`; webhook controller test now asserts `$event->total->toCents() === 9900`. The `PostsVatlyWebhooks` helper already built `Money` for events.
- **Docs**: README + `docs/Webhooks.md` updated for the Money-typed event fields (`$event->total->toCents()` / `->currency`), the removed standalone `currency` on order/refund events, the kept `currency` on chargeback events, and the `OrderLineData` namespace move.

## Gates

- `vendor/bin/phpunit` — 112 passed (307 assertions)
- `vendor/bin/phpstan analyse --memory-limit=1G` — no errors
- `vendor/bin/pint --test` — passed