### PR TITLE
docs: use real subscription_plan_<id> format (drop bogus plan_premium)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,13 @@ Pin to an exact version during alpha — the API will change.
 ## Usage
 
 ```php
+// Vatly ids are prefixed — subscription plans are `subscription_plan_…`,
+// one-off products `one_off_product_…`. Find them in the Vatly dashboard
+// or via `GET /subscription-plans`.
+
 // Start a subscription checkout
 $checkout = $user->subscribe()
-    ->toPlan('plan_premium')
+    ->toPlan('subscription_plan_7Hd9Kf2Lm')
     ->create();
 
 return redirect($checkout->links->checkoutUrl->href);
@@ -89,19 +93,21 @@ return redirect($checkout->links->checkoutUrl->href);
 // Start it with a free trial — billing begins after the trial elapses.
 // Either set whole days…
 $user->subscribe()
-    ->toPlan('plan_premium')
+    ->toPlan('subscription_plan_7Hd9Kf2Lm')
     ->withTrialDays(14)
     ->create();
 
 // …or an end date (rounded up to whole days, so the trial never ends early):
 $user->subscribe()
-    ->toPlan('plan_premium')
+    ->toPlan('subscription_plan_7Hd9Kf2Lm')
     ->withTrialEndsAt(now()->addMonth())
     ->create();
 
 // One-off checkouts with explicit items
+// Each item id is a Vatly product: `one_off_product_…` for a one-off product
+// or `subscription_plan_…` for a subscription plan.
 $checkout = $user->checkout()->create(
-    items: [['id' => 'plan_premium', 'quantity' => 1]],
+    items: [['id' => 'one_off_product_3Qb8Wz1Yt', 'quantity' => 1]],
     redirectUrlSuccess: 'https://example.com/success',
     redirectUrlCanceled: 'https://example.com/canceled',
 );
@@ -109,7 +115,7 @@ $checkout = $user->checkout()->create(
 // Guest checkout: put {CHECKOUT_ID} in the return URL — Vatly fills it in,
 // and claimVatlyCustomerFromReturn() links the purchase on the way back.
 $user->checkout()->create(
-    items: [['id' => 'plan_premium', 'quantity' => 1]],
+    items: [['id' => 'one_off_product_3Qb8Wz1Yt', 'quantity' => 1]],
     redirectUrlSuccess: route('vatly.return').'?checkout_id={CHECKOUT_ID}',
     redirectUrlCanceled: 'https://example.com/billing',
 );
@@ -126,7 +132,7 @@ $user->subscription()->valid();
 $user->subscription()->ended();
 
 // Subscription operations
-$user->subscription()->swap('plan_premium');
+$user->subscription()->swap('subscription_plan_7Hd9Kf2Lm');
 $user->subscription()->cancel();                        // Vatly decides immediate vs grace
 $user->subscription()->resume();                        // while in grace period
 $user->subscription()->updateBilling();                 // signed link for hosted update flow

--- a/docs/Subscriptions.md
+++ b/docs/Subscriptions.md
@@ -6,7 +6,7 @@ Vatly Laravel provides a full subscription lifecycle: creating, checking, swappi
 
 ```php
 $checkout = $user->subscribe()
-    ->toPlan('plan_premium')
+    ->toPlan('subscription_plan_annual')
     ->create();
 
 return redirect($checkout->links->checkoutUrl->href);
@@ -19,14 +19,14 @@ Trials defer the first charge until the trial elapses. Set them on the builder, 
 ```php
 // Whole days from checkout creation
 $user->subscribe()
-    ->toPlan('plan_premium')
+    ->toPlan('subscription_plan_annual')
     ->withTrialDays(14)
     ->create();
 
 // Or an end date — the remaining time is rounded *up* to whole days, so the
 // trial never ends earlier than requested (Vatly's trial input is day-granular)
 $user->subscribe()
-    ->toPlan('plan_premium')
+    ->toPlan('subscription_plan_annual')
     ->withTrialEndsAt(now()->addMonth())
     ->create();
 ```


### PR DESCRIPTION
## What

Docs-only fix. The README and subscription docs used a bogus `plan_premium` placeholder for Vatly plan/product ids. The real Vatly id format is prefixed:

- subscription plans: `subscription_plan_<id>`
- one-off products: `one_off_product_<id>`

(Confirmed: vatlify `SubscriptionPlanManagementProcessIdentifier::PREFIX = 'subscription_plan_'`.)

## Changes

- `README.md`
  - Added a short note explaining Vatly ids are prefixed and where to find them (dashboard / `GET /subscription-plans`).
  - `subscribe()->toPlan(...)` (3×) and `subscription()->swap(...)` → `subscription_plan_7Hd9Kf2Lm`.
  - `checkout()->create(items: [['id' => ...]])` (2×) → `one_off_product_3Qb8Wz1Yt`, with a comment clarifying item ids are products (`one_off_product_…` or `subscription_plan_…`).
- `docs/Subscriptions.md`
  - The three `->toPlan('plan_premium')` → `subscription_plan_annual`, matching the `swap`/`swapAndInvoice` examples already in that file.

No code changed — only `.md` files. Grep confirms zero remaining `plan_premium` in README/docs.