### PR TITLE
chore: bump fluent to alpha.19 (payload-built webhook events)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "illuminate/http": "^12.0|^13.0",
         "illuminate/routing": "^12.0|^13.0",
         "illuminate/support": "^12.0|^13.0",
-        "vatly/vatly-fluent-php": "^0.8.0-alpha.18"
+        "vatly/vatly-fluent-php": "^0.8.0-alpha.19"
     },
     "require-dev": {
         "larastan/larastan": "^3.9",

--- a/tests/Feature/AnonymousCheckoutFlowTest.php
+++ b/tests/Feature/AnonymousCheckoutFlowTest.php
@@ -45,10 +45,7 @@ class AnonymousCheckoutFlowTest extends BaseTestCase
     {
         $anonymousCustomerId = 'cus_anon_alice';
 
-        // Stage the order.paid mock up-front. Fluent's GetOrder action is
-        // captured the moment the WebhookProcessor is first resolved, so the
-        // mock must be in place before any webhook lands.
-        $this->fakeGetOrder($this->buildApiOrder([
+        $anonOrder = $this->buildApiOrder([
             'id' => 'order_anon_1',
             'customerId' => $anonymousCustomerId,
             'totalValue' => '99.00',
@@ -59,7 +56,7 @@ class AnonymousCheckoutFlowTest extends BaseTestCase
             'taxRates' => [
                 ['name' => 'VAT', 'percentage' => 21.0, 'taxablePercentage' => 100.0, 'amount' => '17.18'],
             ],
-        ]));
+        ]);
 
         // ---------------- 1. Anonymous visitor's subscription starts. ----------------
         // No User row exists yet; the webhook arrives for a Vatly customer
@@ -67,20 +64,13 @@ class AnonymousCheckoutFlowTest extends BaseTestCase
 
         $this->assertDatabaseMissing('users', ['vatly_id' => $anonymousCustomerId]);
 
-        $this->fakeGetSubscription($this->buildApiSubscription([
+        $this->postSubscriptionWebhook('subscription.started', $this->buildApiSubscription([
             'id' => 'sub_anon_1',
             'customerId' => $anonymousCustomerId,
             'subscriptionPlanId' => 'plan_basic',
             'name' => 'Basic',
             'quantity' => 1,
-        ]));
-
-        $this->postWebhookEvent('subscription.started', 'sub_anon_1', 'subscription', [
-            'customerId' => $anonymousCustomerId,
-            'subscriptionPlanId' => 'plan_basic',
-            'quantity' => 1,
-            'name' => 'Basic',
-        ])->assertStatus(201);
+        ]))->assertStatus(201);
 
         // The subscription was persisted with the Vatly customer id but no host owner.
         $sub = Subscription::where('vatly_id', 'sub_anon_1')->firstOrFail();
@@ -89,12 +79,7 @@ class AnonymousCheckoutFlowTest extends BaseTestCase
         $this->assertNull($sub->owner_type);
 
         // ---------------- 2. Same anonymous customer pays an order. ----------------
-        $this->postWebhookEvent('order.paid', 'order_anon_1', 'order', [
-            'customerId' => $anonymousCustomerId,
-            'total' => ['currency' => 'EUR', 'value' => '99.00'],
-            'invoiceNumber' => 'INV-ANON-001',
-            'paymentMethod' => 'card',
-        ])->assertStatus(201);
+        $this->postOrderWebhook('order.paid', $anonOrder)->assertStatus(201);
 
         $order = Order::where('vatly_id', 'order_anon_1')->firstOrFail();
         $this->assertSame($anonymousCustomerId, $order->customer_id);
@@ -147,36 +132,21 @@ class AnonymousCheckoutFlowTest extends BaseTestCase
     public function test_claim_does_not_touch_purchases_belonging_to_a_different_anonymous_customer(): void
     {
         // Two distinct anonymous customers each made a purchase.
-        $this->fakeGetSubscriptions([
-            'sub_alice' => $this->buildApiSubscription([
-                'id' => 'sub_alice',
-                'customerId' => 'cus_alice',
-                'subscriptionPlanId' => 'plan_basic',
-                'name' => 'Basic',
-                'quantity' => 1,
-            ]),
-            'sub_bob' => $this->buildApiSubscription([
-                'id' => 'sub_bob',
-                'customerId' => 'cus_bob',
-                'subscriptionPlanId' => 'plan_basic',
-                'name' => 'Basic',
-                'quantity' => 1,
-            ]),
-        ]);
-
-        $this->postWebhookEvent('subscription.started', 'sub_alice', 'subscription', [
+        $this->postSubscriptionWebhook('subscription.started', $this->buildApiSubscription([
+            'id' => 'sub_alice',
             'customerId' => 'cus_alice',
             'subscriptionPlanId' => 'plan_basic',
-            'quantity' => 1,
             'name' => 'Basic',
-        ])->assertStatus(201);
+            'quantity' => 1,
+        ]))->assertStatus(201);
 
-        $this->postWebhookEvent('subscription.started', 'sub_bob', 'subscription', [
+        $this->postSubscriptionWebhook('subscription.started', $this->buildApiSubscription([
+            'id' => 'sub_bob',
             'customerId' => 'cus_bob',
             'subscriptionPlanId' => 'plan_basic',
-            'quantity' => 1,
             'name' => 'Basic',
-        ])->assertStatus(201);
+            'quantity' => 1,
+        ]))->assertStatus(201);
 
         // Alice signs up and claims her purchase.
         $alice = User::factory()->create(['email' => 'alice@example.test', 'vatly_id' => null]);
@@ -193,13 +163,7 @@ class AnonymousCheckoutFlowTest extends BaseTestCase
 
     public function test_subsequent_webhook_after_signup_arrives_already_attributed(): void
     {
-        // Stage the order.paid mock up-front; fluent's GetOrder is cached on
-        // the composition root the moment a WebhookProcessor is resolved, so
-        // any fakeGetOrder() call has to land before that resolution to take
-        // effect. (Calling it after the first webhook works in principle —
-        // we clear the relevant caches — but real apps don't switch the
-        // GetOrder action mid-test, so we mirror that here.)
-        $this->fakeGetOrder($this->buildApiOrder([
+        $postSignupApiOrder = $this->buildApiOrder([
             'id' => 'order_post_signup',
             'customerId' => 'cus_charlie',
             'totalValue' => '19.00',
@@ -210,23 +174,16 @@ class AnonymousCheckoutFlowTest extends BaseTestCase
             'taxRates' => [
                 ['name' => 'VAT', 'percentage' => 21.0, 'taxablePercentage' => 100.0, 'amount' => '3.30'],
             ],
-        ]));
+        ]);
 
-        $this->fakeGetSubscription($this->buildApiSubscription([
+        // Anonymous purchase lands first.
+        $this->postSubscriptionWebhook('subscription.started', $this->buildApiSubscription([
             'id' => 'sub_first',
             'customerId' => 'cus_charlie',
             'subscriptionPlanId' => 'plan_basic',
             'name' => 'Basic',
             'quantity' => 1,
-        ]));
-
-        // Anonymous purchase lands first.
-        $this->postWebhookEvent('subscription.started', 'sub_first', 'subscription', [
-            'customerId' => 'cus_charlie',
-            'subscriptionPlanId' => 'plan_basic',
-            'quantity' => 1,
-            'name' => 'Basic',
-        ])->assertStatus(201);
+        ]))->assertStatus(201);
 
         // User signs up and claims.
         $user = User::factory()->create(['email' => 'charlie@example.test', 'vatly_id' => null]);
@@ -235,12 +192,7 @@ class AnonymousCheckoutFlowTest extends BaseTestCase
         // A follow-up webhook for the same Vatly customer (e.g. they bought
         // a second plan after signing up) now finds the binding in place
         // and writes the host owner directly — no claim step needed.
-        $this->postWebhookEvent('order.paid', 'order_post_signup', 'order', [
-            'customerId' => 'cus_charlie',
-            'total' => ['currency' => 'EUR', 'value' => '19.00'],
-            'invoiceNumber' => 'INV-POST-001',
-            'paymentMethod' => 'card',
-        ])->assertStatus(201);
+        $this->postOrderWebhook('order.paid', $postSignupApiOrder)->assertStatus(201);
 
         $postSignupOrder = Order::where('vatly_id', 'order_post_signup')->firstOrFail();
         $this->assertSame($user->id, $postSignupOrder->owner_id);
@@ -252,23 +204,14 @@ class AnonymousCheckoutFlowTest extends BaseTestCase
         // Two anonymous customers, each with their own subscription persisted
         // via webhook, and each with their own checkout id (one browser tab
         // per checkout — the multi-tab failure mode of a shared session).
-        $this->fakeGetSubscriptions([
-            'sub_alice' => $this->buildApiSubscription([
-                'id' => 'sub_alice', 'customerId' => 'cus_alice',
-                'subscriptionPlanId' => 'plan_basic', 'name' => 'Basic', 'quantity' => 1,
-            ]),
-            'sub_bob' => $this->buildApiSubscription([
-                'id' => 'sub_bob', 'customerId' => 'cus_bob',
-                'subscriptionPlanId' => 'plan_basic', 'name' => 'Basic', 'quantity' => 1,
-            ]),
-        ]);
-
-        $this->postWebhookEvent('subscription.started', 'sub_alice', 'subscription', [
-            'customerId' => 'cus_alice', 'subscriptionPlanId' => 'plan_basic', 'quantity' => 1, 'name' => 'Basic',
-        ])->assertStatus(201);
-        $this->postWebhookEvent('subscription.started', 'sub_bob', 'subscription', [
-            'customerId' => 'cus_bob', 'subscriptionPlanId' => 'plan_basic', 'quantity' => 1, 'name' => 'Basic',
-        ])->assertStatus(201);
+        $this->postSubscriptionWebhook('subscription.started', $this->buildApiSubscription([
+            'id' => 'sub_alice', 'customerId' => 'cus_alice',
+            'subscriptionPlanId' => 'plan_basic', 'name' => 'Basic', 'quantity' => 1,
+        ]))->assertStatus(201);
+        $this->postSubscriptionWebhook('subscription.started', $this->buildApiSubscription([
+            'id' => 'sub_bob', 'customerId' => 'cus_bob',
+            'subscriptionPlanId' => 'plan_basic', 'name' => 'Basic', 'quantity' => 1,
+        ]))->assertStatus(201);
 
         // Both checkouts are resolvable; each carries its own customer.
         $this->fakeGetCheckouts([

--- a/tests/Http/Controllers/VatlyInboundWebhookControllerTest.php
+++ b/tests/Http/Controllers/VatlyInboundWebhookControllerTest.php
@@ -44,20 +44,13 @@ class VatlyInboundWebhookControllerTest extends BaseTestCase
     {
         User::factory()->create(['vatly_id' => 'customer_foo']);
 
-        $this->fakeGetSubscription($this->buildApiSubscription([
+        $response = $this->postSubscriptionWebhook('subscription.started', $this->buildApiSubscription([
             'id' => 'sub_123',
             'customerId' => 'customer_foo',
             'subscriptionPlanId' => 'plan_foo',
             'name' => 'Test Plan',
             'quantity' => 1,
         ]));
-
-        $response = $this->postWebhookEvent('subscription.started', 'sub_123', 'subscription', [
-            'customerId' => 'customer_foo',
-            'subscriptionPlanId' => 'plan_foo',
-            'quantity' => 1,
-            'name' => 'Test Plan',
-        ]);
 
         $response->assertStatus(201);
         $this->assertDatabaseCount('vatly_webhook_calls', 1);
@@ -121,7 +114,7 @@ class VatlyInboundWebhookControllerTest extends BaseTestCase
     {
         $user = User::factory()->create(['vatly_id' => 'customer_abc']);
 
-        $this->fakeGetSubscription($this->buildApiSubscription([
+        $response = $this->postSubscriptionWebhook('subscription.started', $this->buildApiSubscription([
             'id' => 'sub_999',
             'customerId' => 'customer_abc',
             'subscriptionPlanId' => 'plan_premium',
@@ -129,13 +122,6 @@ class VatlyInboundWebhookControllerTest extends BaseTestCase
             'quantity' => 1,
             'mandate' => new Mandate('card', '4242'),
         ]));
-
-        $response = $this->postWebhookEvent('subscription.started', 'sub_999', 'subscription', [
-            'customerId' => 'customer_abc',
-            'subscriptionPlanId' => 'plan_premium',
-            'quantity' => 1,
-            'name' => 'Premium Plan',
-        ]);
 
         $response->assertStatus(201);
         $this->assertDatabaseHas('vatly_subscriptions', [
@@ -152,7 +138,7 @@ class VatlyInboundWebhookControllerTest extends BaseTestCase
     {
         $user = User::factory()->create(['vatly_id' => 'customer_abc']);
 
-        $this->fakeGetOrder($this->buildApiOrder([
+        $response = $this->postOrderWebhook('order.paid', $this->buildApiOrder([
             'id' => 'order_abc123',
             'customerId' => 'customer_abc',
             'totalValue' => '99.00',
@@ -164,13 +150,6 @@ class VatlyInboundWebhookControllerTest extends BaseTestCase
                 ['name' => 'VAT', 'percentage' => 21.0, 'taxablePercentage' => 100.0, 'amount' => '17.18'],
             ],
         ]));
-
-        $response = $this->postWebhookEvent('order.paid', 'order_abc123', 'order', [
-            'customerId' => 'customer_abc',
-            'total' => ['currency' => 'EUR', 'value' => '99.00'],
-            'invoiceNumber' => 'INV-001',
-            'paymentMethod' => 'card',
-        ]);
 
         $response->assertStatus(201);
         $this->assertDatabaseHas('vatly_orders', [
@@ -186,7 +165,7 @@ class VatlyInboundWebhookControllerTest extends BaseTestCase
     {
         $user = User::factory()->create(['vatly_id' => 'customer_abc']);
 
-        $this->fakeGetOrder($this->buildApiOrder([
+        $response = $this->postOrderWebhook('order.paid', $this->buildApiOrder([
             'id' => 'order_tax_1',
             'customerId' => 'customer_abc',
             'totalValue' => '49.99',
@@ -198,11 +177,6 @@ class VatlyInboundWebhookControllerTest extends BaseTestCase
                 ['name' => 'Sales Tax', 'percentage' => 21.0, 'taxablePercentage' => 100.0, 'amount' => '8.68'],
             ],
         ]));
-
-        $response = $this->postWebhookEvent('order.paid', 'order_tax_1', 'order', [
-            'customerId' => 'customer_abc',
-            'total' => ['currency' => 'USD', 'value' => '49.99'],
-        ]);
 
         $response->assertStatus(201);
 
@@ -222,7 +196,7 @@ class VatlyInboundWebhookControllerTest extends BaseTestCase
     {
         User::factory()->create(['vatly_id' => 'customer_abc']);
 
-        $this->fakeGetOrder($this->buildApiOrder([
+        $response = $this->postOrderWebhook('order.paid', $this->buildApiOrder([
             'id' => 'order_lines_wh',
             'customerId' => 'customer_abc',
             'totalValue' => '99.00',
@@ -246,13 +220,6 @@ class VatlyInboundWebhookControllerTest extends BaseTestCase
                 ],
             ],
         ]));
-
-        $response = $this->postWebhookEvent('order.paid', 'order_lines_wh', 'order', [
-            'customerId' => 'customer_abc',
-            'total' => ['currency' => 'EUR', 'value' => '99.00'],
-            'invoiceNumber' => 'INV-010',
-            'paymentMethod' => 'card',
-        ]);
 
         $response->assertStatus(201);
         $this->assertDatabaseHas('vatly_order_lines', [
@@ -285,14 +252,8 @@ class VatlyInboundWebhookControllerTest extends BaseTestCase
         ]);
         // The reaction mirrors the upstream status verbatim — not a synthetic "failed".
         $apiOrder->status = 'pending';
-        $this->fakeGetOrder($apiOrder);
 
-        $response = $this->postWebhookEvent('order.payment_failed', 'order_failed_1', 'order', [
-            'customerId' => 'customer_abc',
-            'total' => ['currency' => 'EUR', 'value' => '99.00'],
-            'invoiceNumber' => 'INV-009',
-            'paymentMethod' => 'card',
-        ]);
+        $response = $this->postOrderWebhook('order.payment_failed', $apiOrder);
 
         $response->assertStatus(201);
         $this->assertDatabaseHas('vatly_orders', [
@@ -323,12 +284,8 @@ class VatlyInboundWebhookControllerTest extends BaseTestCase
             ],
         ]);
         $apiOrder->status = 'pending';
-        $this->fakeGetOrder($apiOrder);
 
-        $this->postWebhookEvent('order.payment_failed', 'order_failed_2', 'order', [
-            'customerId' => 'customer_abc',
-            'total' => ['currency' => 'EUR', 'value' => '99.00'],
-        ])->assertStatus(201);
+        $this->postOrderWebhook('order.payment_failed', $apiOrder)->assertStatus(201);
 
         Event::assertDispatched(
             OrderPaymentFailed::class,
@@ -346,7 +303,7 @@ class VatlyInboundWebhookControllerTest extends BaseTestCase
 
         User::factory()->create(['vatly_id' => 'customer_abc']);
 
-        $this->fakeGetOrder($this->buildApiOrder([
+        $this->postOrderWebhook('order.paid', $this->buildApiOrder([
             'id' => 'order_created_evt',
             'customerId' => 'customer_abc',
             'totalValue' => '99.00',
@@ -357,14 +314,7 @@ class VatlyInboundWebhookControllerTest extends BaseTestCase
             'taxRates' => [
                 ['name' => 'VAT', 'percentage' => 21.0, 'taxablePercentage' => 100.0, 'amount' => '17.18'],
             ],
-        ]));
-
-        $this->postWebhookEvent('order.paid', 'order_created_evt', 'order', [
-            'customerId' => 'customer_abc',
-            'total' => ['currency' => 'EUR', 'value' => '99.00'],
-            'invoiceNumber' => 'INV-100',
-            'paymentMethod' => 'card',
-        ])->assertStatus(201);
+        ]))->assertStatus(201);
 
         Event::assertDispatched(
             OrderWasCreatedFromWebhook::class,
@@ -587,7 +537,7 @@ class VatlyInboundWebhookControllerTest extends BaseTestCase
     {
         $user = User::factory()->create(['vatly_id' => 'customer_abc']);
 
-        $this->fakeGetRefund($this->buildApiRefund([
+        $response = $this->postRefundWebhook('refund.completed', $this->buildApiRefund([
             'id' => 'refund_abc123',
             'customerId' => 'customer_abc',
             'originalOrderId' => 'order_abc123',
@@ -599,10 +549,6 @@ class VatlyInboundWebhookControllerTest extends BaseTestCase
                 ['name' => 'VAT', 'percentage' => 21.0, 'taxablePercentage' => 100.0, 'amount' => '17.18'],
             ],
         ]));
-
-        $response = $this->postWebhookEvent('refund.completed', 'refund_abc123', 'refund', [
-            'customerId' => 'customer_abc',
-        ]);
 
         $response->assertStatus(201);
         $this->assertDatabaseHas('vatly_refunds', [
@@ -626,7 +572,7 @@ class VatlyInboundWebhookControllerTest extends BaseTestCase
 
         User::factory()->create(['vatly_id' => 'customer_abc']);
 
-        $this->fakeGetRefund($this->buildApiRefund([
+        $this->postRefundWebhook('refund.completed', $this->buildApiRefund([
             'id' => 'refund_evt_1',
             'customerId' => 'customer_abc',
             'originalOrderId' => 'order_abc123',
@@ -637,11 +583,7 @@ class VatlyInboundWebhookControllerTest extends BaseTestCase
             'taxRates' => [
                 ['name' => 'VAT', 'percentage' => 21.0, 'taxablePercentage' => 100.0, 'amount' => '17.18'],
             ],
-        ]));
-
-        $this->postWebhookEvent('refund.completed', 'refund_evt_1', 'refund', [
-            'customerId' => 'customer_abc',
-        ])->assertStatus(201);
+        ]))->assertStatus(201);
 
         Event::assertDispatched(
             RefundCompleted::class,
@@ -659,7 +601,7 @@ class VatlyInboundWebhookControllerTest extends BaseTestCase
 
         User::factory()->create(['vatly_id' => 'customer_abc']);
 
-        $this->fakeGetRefund($this->buildApiRefund([
+        $this->postRefundWebhook('refund.failed', $this->buildApiRefund([
             'id' => 'refund_evt_2',
             'customerId' => 'customer_abc',
             'originalOrderId' => 'order_abc123',
@@ -670,11 +612,7 @@ class VatlyInboundWebhookControllerTest extends BaseTestCase
             'taxRates' => [
                 ['name' => 'VAT', 'percentage' => 21.0, 'taxablePercentage' => 100.0, 'amount' => '17.18'],
             ],
-        ]));
-
-        $this->postWebhookEvent('refund.failed', 'refund_evt_2', 'refund', [
-            'customerId' => 'customer_abc',
-        ])->assertStatus(201);
+        ]))->assertStatus(201);
 
         Event::assertDispatched(
             RefundFailed::class,
@@ -691,7 +629,7 @@ class VatlyInboundWebhookControllerTest extends BaseTestCase
 
         User::factory()->create(['vatly_id' => 'customer_abc']);
 
-        $this->fakeGetRefund($this->buildApiRefund([
+        $this->postRefundWebhook('refund.canceled', $this->buildApiRefund([
             'id' => 'refund_evt_3',
             'customerId' => 'customer_abc',
             'originalOrderId' => 'order_abc123',
@@ -702,11 +640,7 @@ class VatlyInboundWebhookControllerTest extends BaseTestCase
             'taxRates' => [
                 ['name' => 'VAT', 'percentage' => 21.0, 'taxablePercentage' => 100.0, 'amount' => '17.18'],
             ],
-        ]));
-
-        $this->postWebhookEvent('refund.canceled', 'refund_evt_3', 'refund', [
-            'customerId' => 'customer_abc',
-        ])->assertStatus(201);
+        ]))->assertStatus(201);
 
         Event::assertDispatched(
             RefundCanceled::class,
@@ -723,7 +657,7 @@ class VatlyInboundWebhookControllerTest extends BaseTestCase
 
         User::factory()->create(['vatly_id' => 'customer_abc']);
 
-        $this->fakeGetChargeback($this->buildApiChargeback([
+        $this->postChargebackWebhook('order.chargeback_received', $this->buildApiChargeback([
             'id' => 'chargeback_evt_1',
             'customerId' => 'customer_abc',
             'originalOrderId' => 'order_abc123',
@@ -735,13 +669,7 @@ class VatlyInboundWebhookControllerTest extends BaseTestCase
             'taxRates' => [
                 ['name' => 'VAT', 'percentage' => 21.0, 'taxablePercentage' => 100.0, 'amount' => '17.18'],
             ],
-        ]));
-
-        $this->postWebhookEvent('order.chargeback_received', 'order_abc123', 'order', [
-            'id' => 'chargeback_evt_1',
-            'originalOrderId' => 'order_abc123',
-            'reason' => 'fraud',
-        ])->assertStatus(201);
+        ]))->assertStatus(201);
 
         Event::assertDispatched(
             OrderChargebackReceived::class,
@@ -760,7 +688,7 @@ class VatlyInboundWebhookControllerTest extends BaseTestCase
 
         User::factory()->create(['vatly_id' => 'customer_abc']);
 
-        $this->fakeGetChargeback($this->buildApiChargeback([
+        $this->postChargebackWebhook('order.chargeback_reversed', $this->buildApiChargeback([
             'id' => 'chargeback_evt_2',
             'customerId' => 'customer_abc',
             'originalOrderId' => 'order_abc123',
@@ -772,13 +700,7 @@ class VatlyInboundWebhookControllerTest extends BaseTestCase
             'taxRates' => [
                 ['name' => 'VAT', 'percentage' => 21.0, 'taxablePercentage' => 100.0, 'amount' => '17.18'],
             ],
-        ]));
-
-        $this->postWebhookEvent('order.chargeback_reversed', 'order_abc123', 'order', [
-            'id' => 'chargeback_evt_2',
-            'originalOrderId' => 'order_abc123',
-            'reason' => 'fraud',
-        ])->assertStatus(201);
+        ]))->assertStatus(201);
 
         Event::assertDispatched(
             OrderChargebackReversed::class,
@@ -794,7 +716,7 @@ class VatlyInboundWebhookControllerTest extends BaseTestCase
     {
         $user = User::factory()->create(['vatly_id' => 'customer_abc']);
 
-        $this->fakeGetChargeback($this->buildApiChargeback([
+        $response = $this->postChargebackWebhook('order.chargeback_received', $this->buildApiChargeback([
             'id' => 'chargeback_abc123',
             'customerId' => 'customer_abc',
             'originalOrderId' => 'order_abc123',
@@ -807,12 +729,6 @@ class VatlyInboundWebhookControllerTest extends BaseTestCase
                 ['name' => 'VAT', 'percentage' => 21.0, 'taxablePercentage' => 100.0, 'amount' => '17.18'],
             ],
         ]));
-
-        $response = $this->postWebhookEvent('order.chargeback_received', 'order_abc123', 'order', [
-            'id' => 'chargeback_abc123',
-            'originalOrderId' => 'order_abc123',
-            'reason' => 'fraud',
-        ]);
 
         $response->assertStatus(201);
         $this->assertDatabaseHas('vatly_chargebacks', [
@@ -849,7 +765,7 @@ class VatlyInboundWebhookControllerTest extends BaseTestCase
             'reason' => 'fraud',
         ]);
 
-        $this->fakeGetChargeback($this->buildApiChargeback([
+        $response = $this->postChargebackWebhook('order.chargeback_reversed', $this->buildApiChargeback([
             'id' => 'chargeback_rev1',
             'customerId' => 'customer_abc',
             'originalOrderId' => 'order_abc123',
@@ -862,12 +778,6 @@ class VatlyInboundWebhookControllerTest extends BaseTestCase
                 ['name' => 'VAT', 'percentage' => 21.0, 'taxablePercentage' => 100.0, 'amount' => '17.18'],
             ],
         ]));
-
-        $response = $this->postWebhookEvent('order.chargeback_reversed', 'order_abc123', 'order', [
-            'id' => 'chargeback_rev1',
-            'originalOrderId' => 'order_abc123',
-            'reason' => 'fraud',
-        ]);
 
         $response->assertStatus(201);
         $this->assertDatabaseCount('vatly_chargebacks', 1);

--- a/tests/TestHelpers/PostsVatlyWebhooks.php
+++ b/tests/TestHelpers/PostsVatlyWebhooks.php
@@ -12,27 +12,28 @@ use Vatly\API\Resources\Chargeback as ApiChargeback;
 use Vatly\API\Resources\Checkout as ApiCheckout;
 use Vatly\API\Resources\Order as ApiOrder;
 use Vatly\API\Resources\Refund as ApiRefund;
+use Vatly\API\Resources\ResourceFactory;
 use Vatly\API\Resources\Subscription as ApiSubscription;
 use Vatly\API\Types\Mandate;
 use Vatly\API\Types\Money;
 use Vatly\API\Types\TaxSummaryCollection;
 use Vatly\API\VatlyApiClient;
-use Vatly\Fluent\Actions\GetChargeback;
 use Vatly\Fluent\Actions\GetCheckout;
-use Vatly\Fluent\Actions\GetOrder;
-use Vatly\Fluent\Actions\GetRefund;
-use Vatly\Fluent\Actions\GetSubscription;
 use Vatly\Fluent\Vatly;
 use Vatly\Fluent\Webhooks\WebhookProcessor;
 
 /**
  * Test helper for driving the Vatly webhook controller end-to-end.
  *
- * Builds + signs the JSON payload Vatly would POST, swaps the cached
- * `GetOrder` action on the composition root so order.paid handling
- * doesn't need a real API, and exposes a small toolkit
- * (`postWebhook`, `makeWebhookPayload`, `fakeGetOrder`, `buildApiOrder`)
- * shared by the controller test and the higher-level flow tests.
+ * Builds + signs the fat JSON payload Vatly would POST. As of
+ * vatly-fluent-php alpha.19 the webhook event factory hydrates the
+ * money/tax-bearing events straight from the signed payload (no follow-up
+ * `GET`), so the `post*Webhook` helpers serialize a built api-php Resource
+ * into the delivery's `object`. The `fakeGetCheckout(s)` helpers remain for
+ * the anonymous-checkout *return* flow (`claimVatlyCustomerFromReturn`),
+ * which still resolves the checkout through a real fluent `GetCheckout` call.
+ *
+ * Shared by the controller test and the higher-level flow tests.
  */
 trait PostsVatlyWebhooks
 {
@@ -91,26 +92,6 @@ trait PostsVatlyWebhooks
     }
 
     /**
-     * Replace the cached `GetOrder` action on the composition root so
-     * the `order.paid` webhook flow doesn't need a real API call. Clears
-     * the downstream WebhookEventFactory / WebhookProcessor caches so
-     * they re-resolve through the mocked action.
-     */
-    protected function fakeGetOrder(ApiOrder $order): void
-    {
-        $action = Mockery::mock(GetOrder::class);
-        $action->shouldReceive('execute')->andReturn($order);
-
-        $vatly = $this->app->make(Vatly::class);
-
-        $this->writeVatlyPrivate($vatly, 'getOrder', $action);
-        $this->writeVatlyPrivate($vatly, 'webhookEventFactory', null);
-        $this->writeVatlyPrivate($vatly, 'webhookProcessor', null);
-
-        $this->app->forgetInstance(WebhookProcessor::class);
-    }
-
-    /**
      * Replace the cached `GetCheckout` action on the composition root so the
      * anonymous-checkout return flow (`claimVatlyCustomerFromReturn`) doesn't
      * need a real API call. Convenience wrapper around
@@ -160,93 +141,7 @@ trait PostsVatlyWebhooks
     }
 
     /**
-     * Replace the cached `GetSubscription` action on the composition root
-     * so the `subscription.started` webhook flow doesn't need a real API
-     * call. WebhookEventFactory enriches the event via this action to pull
-     * the mandate summary into the dispatched event.
-     *
-     * Returns the same subscription regardless of which Vatly id is asked
-     * for. For tests that need different subscriptions per id, use
-     * {@see self::fakeGetSubscriptions()}.
-     */
-    /**
-     * Replace the cached `GetRefund` action on the composition root so the
-     * `refund.*` webhook flow doesn't need a real API call. The factory
-     * enriches refund events via this action to carry the full tax breakdown.
-     */
-    protected function fakeGetRefund(ApiRefund $refund): void
-    {
-        $action = Mockery::mock(GetRefund::class);
-        $action->shouldReceive('execute')->andReturn($refund);
-
-        $vatly = $this->app->make(Vatly::class);
-
-        $this->writeVatlyPrivate($vatly, 'getRefund', $action);
-        $this->writeVatlyPrivate($vatly, 'webhookEventFactory', null);
-        $this->writeVatlyPrivate($vatly, 'webhookProcessor', null);
-
-        $this->app->forgetInstance(WebhookProcessor::class);
-    }
-
-    /**
-     * Replace the cached `GetChargeback` action on the composition root so the
-     * `order.chargeback_*` webhook flow doesn't need a real API call. The
-     * factory enriches chargeback events via this action to carry the customer
-     * id, dispute status, and full tax breakdown.
-     */
-    protected function fakeGetChargeback(ApiChargeback $chargeback): void
-    {
-        $action = Mockery::mock(GetChargeback::class);
-        $action->shouldReceive('execute')->andReturn($chargeback);
-
-        $vatly = $this->app->make(Vatly::class);
-
-        $this->writeVatlyPrivate($vatly, 'getChargeback', $action);
-        $this->writeVatlyPrivate($vatly, 'webhookEventFactory', null);
-        $this->writeVatlyPrivate($vatly, 'webhookProcessor', null);
-
-        $this->app->forgetInstance(WebhookProcessor::class);
-    }
-
-    protected function fakeGetSubscription(ApiSubscription $subscription): void
-    {
-        $this->fakeGetSubscriptions([
-            $subscription->id => $subscription,
-        ], strict: false);
-    }
-
-    /**
-     * Replace the cached `GetSubscription` action with a fake that returns
-     * a different `ApiSubscription` per Vatly subscription id.
-     *
-     * @param  array<string, ApiSubscription>  $subscriptions  keyed by Vatly subscription id
-     * @param  bool  $strict  when true, asking for an id not in the map throws.
-     */
-    protected function fakeGetSubscriptions(array $subscriptions, bool $strict = true): void
-    {
-        $action = Mockery::mock(GetSubscription::class);
-        $action->shouldReceive('execute')->andReturnUsing(function (string $id) use ($subscriptions, $strict) {
-            if (isset($subscriptions[$id])) {
-                return $subscriptions[$id];
-            }
-            if ($strict) {
-                throw new \RuntimeException("No fake ApiSubscription registered for id '{$id}'.");
-            }
-
-            return reset($subscriptions);
-        });
-
-        $vatly = $this->app->make(Vatly::class);
-
-        $this->writeVatlyPrivate($vatly, 'getSubscription', $action);
-        $this->writeVatlyPrivate($vatly, 'webhookEventFactory', null);
-        $this->writeVatlyPrivate($vatly, 'webhookProcessor', null);
-
-        $this->app->forgetInstance(WebhookProcessor::class);
-    }
-
-    /**
-     * Build a minimal ApiSubscription for `fakeGetSubscription()` callers.
+     * Build a minimal ApiSubscription for `subscription.*` webhook tests.
      *
      * @param  array{
      *   id: string,
@@ -275,6 +170,105 @@ trait PostsVatlyWebhooks
         $ref = (new ReflectionClass($target))->getProperty($property);
         $ref->setAccessible(true);
         $ref->setValue($target, $value);
+    }
+
+    /**
+     * Serialize a built api-php Resource back into the API-shaped `object`
+     * tree Vatly embeds on a fat webhook delivery.
+     *
+     * As of vatly-fluent-php alpha.19 the webhook event factory hydrates the
+     * money/tax-bearing events straight from `$webhook->object` (no follow-up
+     * `GET`), so the posted payload must carry the full resource — byte-shaped
+     * like a `GET /…/{id}` body. This reflects the resource's *initialized*
+     * public properties (the builders only set the ones the events read) and
+     * re-encodes the `Money` / `TaxSummaryCollection` / `Mandate` value objects
+     * into the raw array form {@see ResourceFactory} parses.
+     *
+     * @return array<string, mixed>
+     */
+    protected function apiResourceToWebhookObject(object $resource): array
+    {
+        $object = [];
+
+        foreach ((new ReflectionClass($resource))->getProperties() as $property) {
+            if ($property->isStatic() || ! $property->isPublic()) {
+                continue;
+            }
+
+            // Skip typed-but-unset properties the builder never populated, and
+            // the resource's injected api client.
+            if (! $property->isInitialized($resource) || $property->getName() === 'apiClient') {
+                continue;
+            }
+
+            $object[$property->getName()] = $this->encodeWebhookValue($property->getValue($resource));
+        }
+
+        return $object;
+    }
+
+    private function encodeWebhookValue(mixed $value): mixed
+    {
+        if ($value instanceof Money) {
+            return ['currency' => $value->currency, 'value' => $value->value];
+        }
+
+        if ($value instanceof Mandate) {
+            return ['method' => $value->method, 'maskedIdentifier' => $value->maskedIdentifier];
+        }
+
+        if ($value instanceof TaxSummaryCollection) {
+            return array_map(
+                fn ($item) => [
+                    'taxRate' => [
+                        'name' => $item->taxRate->name,
+                        'percentage' => $item->taxRate->percentage,
+                        'taxablePercentage' => $item->taxRate->taxablePercentage,
+                    ],
+                    'amount' => ['currency' => $item->amount->currency, 'value' => $item->amount->value],
+                ],
+                $value->items,
+            );
+        }
+
+        if (is_array($value)) {
+            return array_map(fn ($item) => $this->encodeWebhookValue($item), $value);
+        }
+
+        if ($value instanceof \stdClass) {
+            return (array) $value;
+        }
+
+        return $value;
+    }
+
+    /**
+     * Build + sign + POST an `order.*` webhook carrying the full order as its
+     * fat `object` payload. Replaces the old `fakeGetOrder()` + sparse-payload
+     * dance now that the factory hydrates straight from the payload.
+     */
+    protected function postOrderWebhook(string $eventName, ApiOrder $order): TestResponse
+    {
+        return $this->postWebhookEvent($eventName, $order->id, 'order', $this->apiResourceToWebhookObject($order));
+    }
+
+    protected function postSubscriptionWebhook(string $eventName, ApiSubscription $subscription): TestResponse
+    {
+        return $this->postWebhookEvent($eventName, $subscription->id, 'subscription', $this->apiResourceToWebhookObject($subscription));
+    }
+
+    protected function postRefundWebhook(string $eventName, ApiRefund $refund): TestResponse
+    {
+        return $this->postWebhookEvent($eventName, $refund->id, 'refund', $this->apiResourceToWebhookObject($refund));
+    }
+
+    /**
+     * Chargeback webhooks key on the originating order id (`entityType: order`,
+     * `entityId: <originalOrderId>`); the chargeback itself rides in `object`.
+     */
+    protected function postChargebackWebhook(string $eventName, ApiChargeback $chargeback): TestResponse
+    {
+        return $this->postWebhookEvent($eventName, $chargeback->originalOrderId, 'order', $this->apiResourceToWebhookObject($chargeback));
     }
 
     /**


### PR DESCRIPTION
## What

Adopt **vatly-fluent-php v0.8.0-alpha.19**, which builds webhook events from the signed payload — the event factory now hydrates the api-php Resource straight from `\$webhook->object` (no follow-up enrichment `GET`). This is transparent to this package: webhook handling goes through `Vatly::webhookProcessor()`.

- `composer.json`: `vatly/vatly-fluent-php` → `^0.8.0-alpha.19`
- `composer update vatly/vatly-fluent-php vatly/vatly-api-php --with-all-dependencies` (no lock file — library package)

## Did any code beyond composer.json change?

**No `src/` changes.** As expected, the service provider resolves the processor via `app(Vatly::class)->webhookProcessor()` and there is no direct `WebhookProcessorFactory::create(` or `Get*` action wiring in `src/`, so the bump surfaced no signature mismatch there.

**Test-only changes** were required because the test suite was written for the *old* enrichment-GET reality: each webhook test stubbed a `GetOrder`/`GetSubscription`/`GetRefund`/`GetChargeback` call and posted a sparse `object`. Under alpha.19 the factory ignores those mocks and hydrates the resource from the posted `object`, so the sparse payloads tripped `Typed property … must not be accessed before initialization` (20 failures).

The `PostsVatlyWebhooks` helper now posts the **full resource as the delivery's fat `object`** — serialized from the same built api-php Resource each test already constructs (`apiResourceToWebhookObject()` reflects the resource's initialized public props and re-encodes `Money`/`TaxSummaryCollection`/`Mandate`). The now-dead `fakeGet{Order,Subscription,Refund,Chargeback}` mocks are removed; `fakeGetCheckout(s)` stays — the anonymous-checkout *return* flow (`claimVatlyCustomerFromReturn`) still resolves the checkout through a real `GetCheckout` call, which alpha.19 does not touch.

## Gates (all green)

- `vendor/bin/phpunit` — OK (112 tests, 307 assertions)
- `vendor/bin/phpstan analyse --memory-limit=1G` — No errors
- `vendor/bin/pint --test` — passed

## Versions locked

- `vatly/vatly-fluent-php`: **v0.8.0-alpha.19**
- `vatly/vatly-api-php`: **v0.1.0-alpha.18**

Not live; no tag (release handled separately).