### PR TITLE
feat: VatlyBillable coexistence trait + Cashier comparison/migration docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Full docs at [docs.vatly.com](https://docs.vatly.com). In this repo:
 ## Installation
 
 ```bash
-composer require vatly/vatly-laravel:v0.7.0-alpha.3
+composer require vatly/vatly-laravel:v0.7.0-alpha.14
 ```
 
 Pin to an exact version during alpha — the API will change.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 A Cashier-style integration for [Vatly](https://vatly.com) in your Laravel application. Drop a `Billable` trait on your User model and you get subscriptions, checkouts, customer management, hosted billing update links, and a fully wired webhook endpoint — built around Eloquent and Laravel's IoC, events, and routing.
 
-If you've used Laravel Cashier for Stripe, this will feel familiar. Vatly handles Merchant of Record billing for EU SaaS, so you get a similar developer experience without managing VAT, invoicing, or payment compliance yourself.
+If you've used a Cashier-style billing package, this will feel familiar. Vatly handles Merchant of Record billing for EU SaaS, so you get a similar developer experience without managing VAT, invoicing, or payment compliance yourself.
 
 ## Documentation
 
@@ -23,6 +23,8 @@ Full docs at [docs.vatly.com](https://docs.vatly.com). In this repo:
 - [Subscriptions](docs/Subscriptions.md)
 - [Orders](docs/Orders.md)
 - [Webhooks](docs/Webhooks.md)
+- [How Vatly compares](docs/Comparison.md) — Vatly vs. other Laravel billing packages, for greenfield apps
+- [Running alongside another provider](docs/Coexisting-with-Cashier.md) — adding Vatly next to an existing Merchant of Record, side by side
 
 ## Requirements
 
@@ -77,6 +79,8 @@ Pin to an exact version during alpha — the API will change.
        use Billable;
    }
    ```
+
+   Already running another billing provider and migrating gradually? Reach for the `VatlyBillable` trait instead — it exposes the same surface under `vatly*`-prefixed names, so Vatly sits beside your existing biller without a trait collision. See [Running alongside another provider](docs/Coexisting-with-Cashier.md).
 
 ## Usage
 

--- a/docs/Coexisting-with-Cashier.md
+++ b/docs/Coexisting-with-Cashier.md
@@ -110,7 +110,7 @@ code you have to think about is the trait.
 ### 1. Install and migrate
 
 ```bash
-composer require vatly/vatly-laravel:v0.7.0-alpha.3
+composer require vatly/vatly-laravel:v0.7.0-alpha.14
 
 php artisan vendor:publish --tag=vatly-config
 php artisan vendor:publish --tag=vatly-migrations

--- a/docs/Coexisting-with-Cashier.md
+++ b/docs/Coexisting-with-Cashier.md
@@ -1,0 +1,423 @@
+![Vatly for Laravel](https://raw.githubusercontent.com/Vatly/vatly-laravel/main/art/banner.png)
+
+# Running Vatly next to your current billing provider
+
+You don't swap a Merchant of Record overnight. The payment mandate for every active customer
+lives with your *current* seller of record, and the only way to move a customer is to have them
+re-authorize at the new one. So in practice you run two billing stacks side by side for a while:
+existing customers keep paying through the old provider until they re-subscribe, new signups go
+straight to Vatly, and you retire the old integration once the tail has migrated.
+
+This is the integration playbook for exactly that — adding Vatly beside an existing Cashier-style
+integration ([Stripe](https://laravel.com/docs/12.x/billing) /
+[Paddle](https://laravel.com/docs/12.x/cashier-paddle) /
+[Lemon Squeezy](https://github.com/lmsqueezy/laravel)): the one thing you have to resolve, the
+things that *don't* need resolving, and the step-by-step.
+
+> **Still deciding whether to switch?** Start with [How Vatly compares](Comparison.md) — the
+> side-by-side on the Merchant-of-Record model, features, and what's on the roadmap. This page
+> assumes you've decided to run Vatly alongside what you already have.
+
+---
+
+## The one thing that actually collides: the `Billable` trait
+
+Every package here is modelled on Cashier, so every one ships a `Billable` trait that defines the
+*same* method names:
+
+| Method | Stripe | Paddle | Lemon Squeezy | Vatly |
+|---|:-:|:-:|:-:|:-:|
+| `subscribed()` | ✓ | ✓ | ✓ | ✓ |
+| `subscription()` | ✓ | ✓ | ✓ | ✓ |
+| `subscriptions()` (relation) | ✓ | ✓ | ✓ | ✓ |
+| `checkout()` | ✓ | ✓ | ✓ | ✓ |
+| `subscribe()` | — | ✓ | ✓ | ✓ |
+| `orders()` (relation) | — | — | ✓ | ✓ |
+
+PHP does not let two traits define the same method on one class — you get a fatal
+*"trait method collision"* the moment you write `use LemonSqueezyBillable, VatlyBillable;`. So you
+have to decide, deliberately, **which provider owns the unprefixed method names**.
+
+> [!TIP]
+> **The cleanest fix is often to not share a model at all.** None of these `Billable` traits is
+> tied to `User` — they work on any Eloquent model (`Team`, `Account`, `Organization`, …), and
+> Vatly's records are polymorphic (`owner_type` / `owner_id`). If your app bills a model that
+> isn't already carrying a Cashier-style trait — or you can introduce one — put Vatly's `Billable`
+> there and the collision disappears entirely. When both providers genuinely must live on the
+> *same* model, read on.
+
+> [!IMPORTANT]
+> **The self-call trap.** Plain trait aliasing (`insteadof` / `as`) is *not* enough here, and it
+> fails quietly. Vatly's `subscription()` and `subscribed()` call `$this->subscriptions()`
+> internally. If you alias `subscriptions` to the legacy provider with `insteadof`, then
+> `vatlySubscription()` will read the *legacy* subscriptions table and silently return the wrong
+> thing. Aliasing is safe only for the *builder* methods (`subscribe`, `checkout`) that don't
+> self-call a relation; the *state readers* (`subscription`, `subscribed`) need their relation to
+> stay wired to Vatly.
+
+Because of that trap, the recommended approach below uses Vatly's purpose-built `VatlyBillable`
+trait, which exposes the whole Vatly surface under `vatly*` names and owns its *own*
+`vatlySubscriptions()` relation — so there's nothing to alias and nothing to cross-wire.
+
+### Which provider owns the unprefixed names?
+
+Pick the one most of your code already calls.
+
+- **During a migration, that's almost always the legacy provider.** Don't churn working call
+  sites — keep `$user->subscribed()` meaning "subscribed via your existing provider" and give
+  Vatly a `vatly*` prefix. This is the default below.
+- **Once Vatly is your default** for new signups and the legacy tail is winding down, flip it:
+  make Vatly the plain trait and reach the shrinking legacy cohort through the old provider's
+  models directly.
+
+---
+
+## What *doesn't* collide — and why that's deliberate
+
+The trait is the only friction. Everything underneath is namespaced so the two stacks never
+fight:
+
+**Database tables.** Vatly prefixes every table — `vatly_subscriptions`, `vatly_orders`,
+`vatly_order_lines`, `vatly_refunds`, `vatly_chargebacks`, `vatly_webhook_calls` — and adds a
+single `vatly_id` column to your billable model's table. Nothing of Vatly's overlaps a Cashier
+table. (Worth knowing: Cashier/Stripe and Cashier/Paddle *both* claim the unprefixed
+`subscriptions` table, so they can't run side by side without overriding models. Vatly never
+contends for a table name with anyone.)
+
+**Webhooks.** Each provider registers its own route, verified with its own secret, pointed at its
+own dashboard. Run all of them at once:
+
+| Provider | Route | Signature secret |
+|---|---|---|
+| Stripe | `POST /stripe/webhook` | `STRIPE_WEBHOOK_SECRET` |
+| Paddle | `POST /paddle/webhook` | `PADDLE_WEBHOOK_SECRET` |
+| Lemon Squeezy | `POST /lemon-squeezy/webhook` | `LEMON_SQUEEZY_SIGNING_SECRET` |
+| **Vatly** | `POST /webhooks/vatly` | `VATLY_WEBHOOK_SECRET` |
+
+Vatly uses its own `VATLY_*` environment variables and its own route name (`vatly.webhook`), so
+it never collides with Cashier's `CASHIER_WEBHOOK` env or anyone else's config.
+
+**Config & service bindings.** Vatly binds its services under its own namespace via
+`VatlyServiceProvider`; nothing is rebound out from under your existing provider.
+
+In short: two sets of tables, two webhook endpoints, two dashboards, one model. The only line of
+code you have to think about is the trait.
+
+---
+
+## Add Vatly beside your current provider
+
+### 1. Install and migrate
+
+```bash
+composer require vatly/vatly-laravel:v0.7.0-alpha.3
+
+php artisan vendor:publish --tag=vatly-config
+php artisan vendor:publish --tag=vatly-migrations
+php artisan vendor:publish --tag=vatly-billable-migrations
+php artisan migrate
+```
+
+This adds the `vatly_id` column and the `vatly_*` tables. Your existing tables are untouched. Add
+the Vatly credentials alongside your current ones in `.env`:
+
+```env
+# existing provider stays exactly as-is — its own keys, untouched
+
+# new, additive:
+VATLY_KEY=test_xxxxxxxxxxxx
+VATLY_WEBHOOK_SECRET=your-webhook-secret
+VATLY_REDIRECT_URL_SUCCESS=https://your-app.test/checkout/success
+VATLY_REDIRECT_URL_CANCELED=https://your-app.test/checkout/canceled
+```
+
+### 2. Add the `VatlyBillable` trait
+
+`vatly-laravel` ships a second trait, **`VatlyBillable`**, built for exactly this. It exposes the
+full Vatly surface under `vatly*`-prefixed names — `vatlySubscribe()`, `vatlySubscribed()`,
+`vatlySubscription()`, `vatlyCheckout()`, `vatlyOrder()`, plus the `vatlySubscriptions` /
+`vatlyOrders` / `vatlyRefunds` / `vatlyChargebacks` relations — so it drops in beside any
+Cashier-style `Billable` with no collision and no aliasing. Add it next to the trait you already
+have:
+
+```php
+// app/Models/User.php
+use LemonSqueezy\Laravel\Billable;   // your existing provider — unchanged
+use Vatly\Laravel\VatlyBillable;     // Vatly, under vatly* names
+
+class User extends Authenticatable
+{
+    use Billable;          // $user->subscribed(), $user->checkout(), … → existing provider
+    use VatlyBillable;     // $user->vatlySubscribed(), $user->vatlyCheckout(), … → Vatly
+}
+```
+
+That's the whole integration step. Two things make it safe by construction:
+
+- **The state readers query their own relation.** `vatlySubscribed()` / `vatlySubscription()` read
+  `vatlySubscriptions()`, never an unprefixed `subscriptions()` the other provider owns — so the
+  self-call trap can't bite.
+- **The customer helpers are shared, not duplicated.** Methods whose names already carry "Vatly" —
+  `createAsVatlyCustomer()`, `claimVatlyCustomerFromReturn()`, `asVatlyCustomer()`,
+  `findBillable()` — don't collide, so `VatlyBillable` and the standalone `Billable` share one
+  tested implementation; a fix to the claim / re-attribution logic reaches both.
+
+> **Vatly is your only biller?** Use the plain `Billable` trait instead (`subscribe()`,
+> `subscribed()`, …) — see [Getting started](README.md). `VatlyBillable` exists purely for running
+> beside another provider.
+
+<details>
+<summary>Under the hood — the equivalent hand-written concern</summary>
+
+You never need this; `VatlyBillable` ships with the package. But if you'd rather own the code — to
+rename methods, narrow the surface, or add behavior — it's essentially this trait over Vatly's
+composition root:
+
+```php
+// app/Billing/VatlyBilling.php
+namespace App\Billing;
+
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Http\Request;
+use Vatly\Fluent\Builders\CheckoutBuilder;
+use Vatly\Fluent\Builders\SubscriptionBuilder;
+use Vatly\Fluent\CustomerProfile;
+use Vatly\Fluent\SubscriptionHandle;
+use Vatly\Fluent\Vatly;
+use Vatly\Laravel\Models\Order as VatlyOrder;
+use Vatly\Laravel\Models\Subscription as VatlySubscription;
+
+trait VatlyBilling
+{
+    /** @return MorphMany<VatlySubscription> */
+    public function vatlySubscriptions(): MorphMany
+    {
+        return $this->morphMany(VatlySubscription::class, 'owner')->orderByDesc('created_at');
+    }
+
+    public function vatlySubscribe(): SubscriptionBuilder
+    {
+        return app(Vatly::class)->subscriptionBuilder($this->vatlyProfile());
+    }
+
+    public function vatlyCheckout(): CheckoutBuilder
+    {
+        return app(Vatly::class)->checkoutBuilder($this->vatlyProfile());
+    }
+
+    public function vatlySubscribed(string $type = VatlySubscription::DEFAULT_TYPE): bool
+    {
+        // Uses our own relation — never the legacy one.
+        $sub = $this->vatlySubscriptions()->where('type', $type)->first();
+
+        return $sub !== null && $sub->isActive();
+    }
+
+    public function vatlySubscription(string $type = VatlySubscription::DEFAULT_TYPE): ?SubscriptionHandle
+    {
+        $sub = $this->vatlySubscriptions()->where('type', $type)->first();
+
+        return $sub !== null ? app(Vatly::class)->subscription($sub) : null;
+    }
+
+    /**
+     * Claim an anonymous Vatly customer on the checkout-success redirect.
+     * Mirrors Vatly\Laravel\VatlyBillable::claimVatlyCustomerFromReturn().
+     */
+    public function claimVatlyCustomerFromReturn(Request $request, string $key = 'checkout_id'): bool
+    {
+        $checkoutId = $request->query($key);
+
+        if (! is_string($checkoutId) || $checkoutId === '') {
+            return false;
+        }
+
+        $customerId = app(Vatly::class)->customerIdFromCheckout($checkoutId);
+
+        if ($customerId === null) {
+            return false;
+        }
+
+        app(Vatly::class)->customers()->attribute($customerId, (string) $this->getKey());
+        $this->forceFill(['vatly_id' => $customerId])->save();
+
+        // Re-attribute rows the webhook persisted during the anonymous flow.
+        $owner = ['owner_type' => $this->getMorphClass(), 'owner_id' => $this->getKey()];
+        VatlySubscription::query()->whereNull('owner_id')->where('customer_id', $customerId)->update($owner);
+        VatlyOrder::query()->whereNull('owner_id')->where('customer_id', $customerId)->update($owner);
+
+        return true;
+    }
+
+    private function vatlyProfile(): CustomerProfile
+    {
+        return new CustomerProfile(
+            vatlyId: $this->vatly_id,
+            email: $this->email,
+            name: $this->name,
+        );
+    }
+}
+```
+
+</details>
+
+<details>
+<summary><strong>Alternative — trait aliasing</strong> (only if you're making Vatly primary)</summary>
+
+`VatlyBillable` keeps the incumbent on the unprefixed names — what you want during a migration. If
+instead you're making **Vatly** primary and pushing the legacy provider under a prefix, use
+Vatly's standalone `Billable` and resolve the collision with `insteadof` / `as`:
+
+```php
+use LemonSqueezy\Laravel\Billable as LegacyBillable;
+use Vatly\Laravel\Billable as VatlyBaseBillable;
+
+class User extends Authenticatable
+{
+    use VatlyBaseBillable, LegacyBillable {
+        // Vatly OWNS the unprefixed names — including subscriptions(), so its
+        // internal self-calls stay correct.
+        VatlyBaseBillable::subscriptions  insteadof LegacyBillable;
+        VatlyBaseBillable::subscription   insteadof LegacyBillable;
+        VatlyBaseBillable::subscribed     insteadof LegacyBillable;
+        VatlyBaseBillable::subscribe      insteadof LegacyBillable;
+        VatlyBaseBillable::checkout       insteadof LegacyBillable;
+        VatlyBaseBillable::orders         insteadof LegacyBillable;
+
+        // Legacy provider moves under a prefix; update its call sites accordingly.
+        LegacyBillable::subscriptions as legacySubscriptions;
+        LegacyBillable::subscription  as legacySubscription;
+        LegacyBillable::subscribed    as legacySubscribed;
+        LegacyBillable::subscribe     as legacySubscribe;
+        LegacyBillable::checkout      as legacyCheckout;
+        LegacyBillable::orders        as legacyOrders;
+    }
+}
+```
+
+Don't hand-alias the inverse (legacy keeps `subscriptions`, Vatly pushed under a prefix) — the
+prefixed Vatly readers would then read the wrong relation, the self-call trap above. That case is
+exactly what `VatlyBillable` is built for, so reach for it instead of aliasing.
+
+</details>
+
+### 3. Decide who bills through whom
+
+Add a column that records which provider owns a given user, and default new signups to Vatly:
+
+```php
+// migration
+$table->string('billing_provider')->default('vatly'); // existing rows: backfill to 'legacy'
+```
+
+```php
+// a single gate your UI and middleware can read
+public function billsThroughVatly(): bool
+{
+    return $this->billing_provider === 'vatly';
+}
+```
+
+Your billing screen then branches on it:
+
+```php
+if ($user->billsThroughVatly()) {
+    $checkout = $user->vatlySubscribe()->toPlan('subscription_plan_7Hd9Kf2Lm')->create();
+
+    return redirect($checkout->links->checkoutUrl->href);
+}
+
+// legacy cohort keeps its current flow until they choose to move
+return redirect($user->checkout('variant-id')); // your existing provider
+```
+
+### 4. Run both webhook endpoints
+
+Nothing special — register Vatly's webhook URL and secret in the Vatly dashboard, keep your
+existing provider's webhook pointed where it already is. Subscriptions and orders from each
+provider sync into their own tables. Listen for Vatly events on Laravel's event bus the usual way
+(see [Webhooks](Webhooks.md)):
+
+```php
+use Vatly\API\Webhooks\Events\SubscriptionStarted;
+
+Event::listen(SubscriptionStarted::class, function (SubscriptionStarted $event) {
+    // a customer is now live on Vatly — safe to wind down their legacy subscription
+});
+```
+
+### 5. Migrate a customer: the re-authorization flow
+
+A MoR mandate belongs to the legal seller — your old provider's mandate is theirs, Vatly's is
+Vatly's. You **cannot** transfer a mandate between Merchants of Record; the customer has to
+authorize payment at the new seller. So a migration is a re-subscribe, sequenced to avoid both a
+double charge and a gap in access:
+
+1. Show the legacy-active customer a "move to Vatly" prompt (a re-authentication, in plain
+   language: "confirm your payment details to switch").
+2. They complete a fresh Vatly checkout — `vatlySubscribe()->toPlan(...)->create()` — which
+   creates the new mandate at Vatly.
+3. On return, `claimVatlyCustomerFromReturn($request)` links the new Vatly customer to the user
+   (guest-checkout and multi-tab safe).
+4. **When Vatly's `SubscriptionStarted` webhook lands** — not before — cancel the legacy
+   subscription at period end (`$user->subscription()->cancel()` on the legacy trait) so the
+   customer is never double-billed and never loses access mid-period.
+5. Flip `billing_provider` to `vatly`.
+
+Order matters: start Vatly only after the customer opts in (no surprise charge), cancel legacy
+only after Vatly is active (no service gap).
+
+---
+
+## Translation cheat-sheet (Cashier → Vatly)
+
+Mapping for the engineer or agent porting a flow. Vatly ids are prefixed —
+`subscription_plan_…` for plans, `one_off_product_…` for one-offs. The Vatly column uses the
+`vatly*` methods from the `VatlyBillable` trait (step 2).
+
+| Task | Cashier (Stripe) | Cashier (Paddle) | Lemon Squeezy | **Vatly** |
+|---|---|---|---|---|
+| Start a subscription | `newSubscription('default','price')->create($pm)` | `subscribe('pri_123','default')` | `subscribe('variant')` | `vatlySubscribe()->toPlan('subscription_plan_…')->create()` |
+| Redirect to checkout | `->checkout([...])` | `->returnTo($url)` (Paddle.js) | redirect / `<x-lemon-button>` | `redirect($checkout->links->checkoutUrl->href)` |
+| Free trial | `->trialDays(14)` | plan-level / `->trialDays()` | plan-level | `->withTrialDays(14)` or `->withTrialEndsAt($date)` |
+| Is subscribed? | `subscribed('default')` | `subscribed()` | `subscribed()` | `vatlySubscribed()` |
+| Get the subscription | `subscription('default')` | `subscription()` | `subscription()` | `vatlySubscription()` |
+| In grace period? | `subscription()->onGracePeriod()` | `->onGracePeriod()` | `->onGracePeriod()` | `vatlySubscription()->onGracePeriod()` |
+| Swap plan | `subscription()->swap('price')` | `->swap('pri')` | `->swap('prod','variant')` | `vatlySubscription()->swap('subscription_plan_…')` |
+| Swap + invoice now | `->swapAndInvoice('price')` | — | `->swapAndInvoice(...)` | `vatlySubscription()->swapAndInvoice('subscription_plan_…')` |
+| Cancel (grace) | `subscription()->cancel()` | `->cancel()` | `->cancel()` | `vatlySubscription()->cancel()` |
+| Resume | `subscription()->resume()` | `->resume()` | `->resume()` | `vatlySubscription()->resume()` |
+| One-off purchase | `checkout(['price'=>1])` | `checkout('pri_123')` | `checkout('variant')` | `vatlyCheckout()->create(items: [['id'=>'one_off_product_…','quantity'=>1]], redirectUrlSuccess: …, redirectUrlCanceled: …)` |
+| Update payment / billing | `redirectToBillingPortal()` | hosted update | `redirect($portalUrl)` | `vatlySubscription()->updateBilling()` |
+| List orders / receipts | `invoices()` | `transactions()` | `orders()` | `$user->vatlyOrders` → `$order->invoiceUrl()` |
+| Customer id field | `stripe_id` | `paddle_id` | (relation) | `vatly_id` |
+
+A couple of shape differences worth flagging for whoever's implementing:
+
+- **Vatly checkout is a server-side redirect**, like Stripe Checkout — you build the checkout
+  server-side and `redirect()` to a hosted URL. Paddle and Lemon Squeezy lean on a client-side JS
+  overlay (`@paddleJS`, `@lemonJS`). If you're moving off an overlay, you're removing front-end
+  JS, not adding it.
+- **Guest checkout** is first-class in Vatly: put `{CHECKOUT_ID}` in your return URL and call
+  `claimVatlyCustomerFromReturn()` on the way back to link the purchase — no session plumbing,
+  multi-tab safe. See [Customers](Customers.md).
+- **Refunds and chargebacks are real models** in Vatly (`$user->vatlyRefunds`,
+  `$order->chargebacks`, reversal helpers like `$order->isFullyReversed()`), with dedicated
+  webhook events — not something you reconstruct from raw payloads.
+
+---
+
+## Reference
+
+- **Deciding / comparing** → [How Vatly compares](Comparison.md) (Merchant-of-Record model,
+  feature parity, roadmap)
+- **Getting started** → [Getting started](README.md) · [Configuration](configuration.md)
+- **API surface** → [Customers](Customers.md) · [Checkouts](Checkouts.md) · [Subscriptions](Subscriptions.md) · [Orders](Orders.md) · [Webhooks](Webhooks.md)
+
+Compared against, at time of writing:
+[Laravel Cashier (Stripe)](https://laravel.com/docs/12.x/billing) ·
+[Laravel Cashier (Paddle)](https://laravel.com/docs/12.x/cashier-paddle) ·
+[Lemon Squeezy for Laravel](https://github.com/lmsqueezy/laravel).
+Method names and table layouts follow those packages' current releases — verify against the
+version you have pinned before relying on a specific signature.

--- a/docs/Comparison.md
+++ b/docs/Comparison.md
@@ -1,0 +1,190 @@
+![Vatly for Laravel](https://raw.githubusercontent.com/Vatly/vatly-laravel/main/art/banner.png)
+
+# How Vatly for Laravel compares
+
+Picking the billing layer for a new Laravel app? If you've reached for Laravel Cashier
+before, Vatly will feel immediately familiar — a `Billable` trait, `subscribed()`,
+`subscription()->swap()`, a wired-up webhook endpoint. The difference is what sits *behind*
+the API: Vatly is a **Merchant of Record**, so it is the legal seller and handles VAT,
+invoicing, and payment compliance for you — and it's **Europe-first**, operating under EU
+jurisdiction.
+
+This page is an honest, side-by-side look at how `vatly-laravel` stacks up against the
+Cashier-style packages you might otherwise reach for —
+[Laravel Cashier (Stripe)](https://laravel.com/docs/12.x/billing),
+[Laravel Cashier (Paddle)](https://laravel.com/docs/12.x/cashier-paddle), and
+[Lemon Squeezy for Laravel](https://github.com/lmsqueezy/laravel) — gaps included.
+
+> **Already running one of these in an existing app?** This page helps you choose. Once you
+> have, [Running alongside another provider](Coexisting-with-Cashier.md) shows how to add Vatly
+> next to your current biller and migrate customers over gradually.
+
+---
+
+## At a glance
+
+| | Cashier (Stripe Billing) | Cashier (Paddle) | Lemon Squeezy | **Vatly** |
+|---|---|---|---|---|
+| Composer package | `laravel/cashier` | `laravel/cashier-paddle` | `lemonsqueezy/laravel` | `vatly/vatly-laravel` |
+| Billable trait | `Laravel\Cashier\Billable` | `Laravel\Paddle\Billable` | `LemonSqueezy\Laravel\Billable` | `Vatly\Laravel\Billable` |
+| Merchant of Record | **No** — you are the seller | Yes | Yes | **Yes (full)** |
+| Entity / jurisdiction | *You* (wherever you're registered) | Paddle, **UK** | Lemon Squeezy, **US** (Stripe-owned) | **EEA / EU jurisdiction** |
+| Who remits VAT/sales tax | **You** (Stripe Tax only *calculates*) | Provider | Provider | **Provider** |
+| Customer stored as | columns on the billable model (`stripe_id`, …) | `customers` table (`paddle_id`) | `lemon_squeezy_customers` table | `vatly_id` column on the billable model + `vatly_*` tables |
+| Checkout | Stripe Checkout (hosted) / Elements | Paddle.js **overlay / inline** (client-side JS) | Lemon.js overlay / hosted URL | **Vatly-hosted redirect** (+ guest claim) |
+| Webhook route | `/stripe/webhook` | `/paddle/webhook` | `/lemon-squeezy/webhook` | `/webhooks/vatly` |
+| Coupons / promo codes | Yes | Yes | Yes | **On the roadmap** (workaround below) |
+| License keys | No | No | Yes | **On the roadmap** (rarely needed for SaaS) |
+| Refunds & chargebacks | wire it yourself | events | events | **first-class models + events** |
+| Trials, swap, grace/resume | Yes | Yes | Yes | **Yes** |
+
+Three things to take from this table:
+
+1. **The Laravel Cashier (Stripe) package is not a Merchant-of-Record path.** `laravel/cashier`
+   drives *classic Stripe Billing*, where **you** are the seller of record: you register for
+   VAT/sales tax wherever you cross a threshold, you file, you remit, you issue compliant
+   invoices. [Stripe Tax](https://stripe.com/tax) (`Cashier::calculateTaxes()`) computes the
+   rate; the legal and operational burden stays with you. Paddle, Lemon Squeezy and Vatly are
+   the seller instead.
+2. **Stripe *the company* does now offer an MoR — [Stripe Managed Payments](https://stripe.com/managed-payments) —
+   but it's a different product, not the Cashier you're running.** It withholds VAT/GST/sales tax
+   across 80+ countries and takes on fraud, disputes and transaction support. Three things to know
+   before you lean on it: you reach it through *Stripe Checkout / Payment Links* with
+   `managed_payments` enabled, **not** through Cashier's subscription API today; Stripe itself
+   describes it as not yet a *complete* MoR (you stay responsible in unsupported territories and
+   for parts of dispute/refund handling); and it's a **US** company's offering — it's also where
+   [Lemon Squeezy is being folded in](https://www.lemonsqueezy.com/blog/2026-update).
+3. **Among the MoRs, the deciding difference is where the entity sits.** Paddle is UK-based;
+   Lemon Squeezy and Stripe Managed Payments are US. Vatly is EEA-based, under EU jurisdiction —
+   your customer data and your seller-of-record relationship stay in Europe. That, not the API,
+   is the reason to choose one over another.
+
+---
+
+## What a Merchant of Record actually changes for you
+
+The Laravel surfaces are nearly identical; the operational reality is not.
+
+**Without an MoR** (Cashier on classic Stripe Billing), *you* are the seller. You own VAT and
+sales-tax registration across every jurisdiction you cross a threshold in, the threshold
+monitoring itself, filing and remittance, compliant invoice generation, and the liability when
+it's wrong. Stripe Tax computes the right rate; everything around it is yours to build and run.
+
+**With Vatly** (a full MoR), the platform is the legal seller of record: it charges the
+customer, applies the correct tax, issues the invoice, remits to the authorities, and carries
+the compliance. You integrate subscriptions and gate features on `subscribed()` — that's the
+extent of what your app owns.
+
+For a new product selling into the EU and worldwide, that's the difference between launching
+now and standing up a tax-and-compliance function first.
+
+---
+
+## The developer experience
+
+For a greenfield app, Vatly is your only biller — so you use the plain `Billable` trait, and
+the code reads like Cashier:
+
+```php
+use Vatly\Laravel\Billable;
+
+class User extends Authenticatable
+{
+    use Billable;
+}
+```
+
+```php
+// Start a subscription — redirect to Vatly's hosted checkout
+$checkout = $user->subscribe()
+    ->toPlan('subscription_plan_7Hd9Kf2Lm')
+    ->withTrialDays(14)
+    ->create();
+
+return redirect($checkout->links->checkoutUrl->href);
+
+// Gate features on subscription state
+if ($user->subscribed()) {
+    // …
+}
+
+$user->subscription()->swap('subscription_plan_other');
+$user->subscription()->cancel();      // Vatly decides immediate vs. grace
+$user->subscription()->resume();      // while on the grace period
+
+// One-off purchase
+$user->checkout()->create(
+    items: [['id' => 'one_off_product_3Qb8Wz1Yt', 'quantity' => 1]],
+    redirectUrlSuccess: route('billing.success'),
+    redirectUrlCanceled: route('billing'),
+);
+
+// Receipts — hosted invoice URLs, no PDF plumbing
+foreach ($user->orders as $order) {
+    echo $order->invoiceUrl();
+}
+```
+
+No VAT logic, no tax tables, no invoice templates, no client-side checkout widget to embed —
+the checkout is a server-side redirect, like Stripe Checkout. See [Subscriptions](Subscriptions.md)
+and [Checkouts](Checkouts.md) for the full surface.
+
+---
+
+## Feature parity, and what's still on the roadmap
+
+Vatly covers what a SaaS needs to start selling: subscriptions with trials, plan swaps,
+cancellation with grace and resume, one-off purchases, hosted checkout, refunds and chargebacks,
+and — because it's a Merchant of Record — VAT, invoicing and tax compliance handled for you. A
+few capabilities you may use elsewhere aren't in the box yet. Here's the honest picture, and how
+to bridge it.
+
+| Capability | Vatly today | Notes |
+|---|---|---|
+| Subscriptions, trials, swap, grace, resume | ✅ | Full lifecycle, Cashier-shaped API |
+| One-off / multi-item checkout | ✅ | `checkout()->create(items: …)` |
+| VAT, invoicing, tax remittance | ✅ | Handled — it's the point of a MoR. With Cashier (classic Stripe Billing) this is *your* job. |
+| Refunds & chargebacks | ✅ | First-class models + events (more than most provide) |
+| Test / live segregation | ✅ | Every record carries `testmode`; key prefix selects the mode |
+| **Coupons / promo codes** | 🔜 Roadmap | Until native codes land, model a promo as a dedicated `subscription_plan_…` at the discounted price and point that cohort at it. A couple of extra plans in the dashboard — not a blocker for launching offers. |
+| **License keys** | 🔜 Roadmap | Vatly is built for SaaS, where entitlement follows subscription state — `subscribed()` *is* your license check. Per-seat keys for downloadable/offline software (Lemon Squeezy's signature feature) aren't here yet. If you ship license-activated desktop binaries, that's the one workflow to keep elsewhere for now. |
+
+The shape of the trade is deliberate: Vatly does the compliance-heavy core that's genuinely
+hard to build — being the seller of record, VAT across the EU, invoicing, disputes — and is
+filling in the conveniences (coupons next) in the open. For a subscription SaaS selling into
+Europe and the world, there's enough here to launch today.
+
+---
+
+## Why teams choose Vatly
+
+Three reasons come up again and again, and none of them are about the API:
+
+- **Europe-first, by design.** EEA-based, EU jurisdiction, customer data kept in Europe. No
+  dependency on US policy, and no awkward answers when an enterprise buyer asks where their data
+  and their seller of record sit.
+- **You never carry compliance.** Classic Stripe Billing leaves VAT registration, filing and
+  remittance with you; Vatly takes it. That's months of work and ongoing operational risk you
+  simply don't own.
+- **One familiar API.** The Cashier-shaped surface means there's little to learn and little to
+  rewrite if you ever did start elsewhere — the reasons to choose Vatly are about who carries the
+  compliance and where the entity sits, not about the code.
+
+> **You Just Ship.**
+
+---
+
+## Next steps
+
+- **Starting fresh** → [Getting started](README.md) wires up the trait, config, migrations and
+  webhook in a few minutes.
+- **Already running another provider** → [Running alongside another provider](Coexisting-with-Cashier.md)
+  shows how to add Vatly beside your current biller and migrate customers over gradually.
+- **Reference** → [Configuration](configuration.md) · [Customers](Customers.md) · [Checkouts](Checkouts.md) · [Subscriptions](Subscriptions.md) · [Orders](Orders.md) · [Webhooks](Webhooks.md)
+
+Compared against, at time of writing:
+[Laravel Cashier (Stripe)](https://laravel.com/docs/12.x/billing) ·
+[Laravel Cashier (Paddle)](https://laravel.com/docs/12.x/cashier-paddle) ·
+[Lemon Squeezy for Laravel](https://github.com/lmsqueezy/laravel).
+Their method names and table layouts follow those packages' current releases — verify against
+the version you have pinned before relying on a specific signature.

--- a/src/Concerns/ManagesVatlyCustomer.php
+++ b/src/Concerns/ManagesVatlyCustomer.php
@@ -1,0 +1,227 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Laravel\Concerns;
+
+use Illuminate\Http\Request;
+use Vatly\API\Resources\Customer;
+use Vatly\Fluent\CustomerProfile;
+use Vatly\Fluent\Exceptions\CustomerAlreadyBoundException;
+use Vatly\Fluent\Vatly;
+use Vatly\Laravel\Billable;
+use Vatly\Laravel\Exceptions\NoVatlyCustomerException;
+use Vatly\Laravel\Models\Order;
+use Vatly\Laravel\Models\Subscription;
+use Vatly\Laravel\VatlyBillable;
+
+/**
+ * Vatly customer identity, creation, claiming and lookup — shared between the
+ * standalone {@see Billable} trait and the prefixed,
+ * coexistence-friendly {@see VatlyBillable} trait.
+ *
+ * Everything here is independent of the subscription/order *relation* names, so
+ * both public traits can compose it without their relation methods colliding.
+ * The method names below already carry "Vatly" (or are otherwise Vatly-specific),
+ * so they never clash with another Cashier-style biller on the same model.
+ *
+ * @property string|null $vatly_id
+ * @property string|null $email
+ * @property string|null $name
+ *
+ * @method static where(string $column, mixed $value)
+ * @method bool save()
+ * @method mixed getKey()
+ * @method string getMorphClass()
+ */
+trait ManagesVatlyCustomer
+{
+    // --- Vatly identity / profile accessors ---
+
+    public function vatlyId(): ?string
+    {
+        return $this->vatly_id;
+    }
+
+    public function hasVatlyId(): bool
+    {
+        return $this->vatly_id !== null;
+    }
+
+    public function vatlyEmail(): ?string
+    {
+        return $this->email ?? null;
+    }
+
+    public function vatlyName(): ?string
+    {
+        return $this->name ?? null;
+    }
+
+    /**
+     * Snapshot the host-side fields fluent uses when talking to the API.
+     */
+    public function customerProfile(): CustomerProfile
+    {
+        return new CustomerProfile(
+            vatlyId: $this->vatlyId(),
+            email: $this->vatlyEmail(),
+            name: $this->vatlyName(),
+        );
+    }
+
+    // --- Customer-creation shortcuts ---
+
+    /**
+     * Create the Vatly customer for this owner and bind the resulting id.
+     *
+     * The host id is written via the configured CustomerBindingRepository
+     * (which for the default Eloquent impl updates the `vatly_id` column
+     * directly). The in-memory model is also refreshed so subsequent calls
+     * see the new id without an extra query.
+     *
+     * `$options` keys not consumed by `email` / `name` (the host-supplied
+     * defaults the trait fills in from this model) are forwarded as-is to
+     * the create-customer API call — `locale`, `metadata`, etc.
+     *
+     * @param  array<string, mixed>  $options  Create-customer API payload keys.
+     *                                         Caller-supplied `email` / `name`
+     *                                         override the host defaults.
+     */
+    public function createAsVatlyCustomer(array $options = []): Customer
+    {
+        $profile = new CustomerProfile(
+            email: $options['email'] ?? $this->vatlyEmail(),
+            name: $options['name'] ?? $this->vatlyName(),
+        );
+
+        unset($options['email'], $options['name']);
+
+        $customer = app(Vatly::class)
+            ->customers()
+            ->createFor((string) $this->getKey(), $profile, $options);
+
+        $this->vatly_id = $customer->id;
+
+        return $customer;
+    }
+
+    public function asVatlyCustomer(): Customer
+    {
+        if (! $this->hasVatlyId()) {
+            throw NoVatlyCustomerException::notYetCreated($this);
+        }
+
+        return app(Vatly::class)->customers()->findByVatlyCustomerId((string) $this->vatlyId());
+    }
+
+    /**
+     * @param  array<string, mixed>  $options
+     */
+    public function createOrGetVatlyCustomer(array $options = []): Customer
+    {
+        if ($this->hasVatlyId()) {
+            return $this->asVatlyCustomer();
+        }
+
+        return $this->createAsVatlyCustomer($options);
+    }
+
+    /**
+     * Claim an anonymous Vatly customer for this host entity.
+     *
+     * Use this on a user-signup hook when the user paid via guest checkout
+     * before the account existed. Pass the Vatly customer id (typically
+     * stashed on the checkout-success redirect or in the session) and this
+     * method:
+     *
+     *   1. binds the Vatly id ↔ host id pair (via the CustomerBindingRepository),
+     *   2. writes `vatly_id` onto this model so subsequent lookups find it,
+     *   3. backfills `owner_type` / `owner_id` on every `vatly_subscriptions`
+     *      and `vatly_orders` row that carries this `customer_id` but had no
+     *      owner yet — the rows the webhook persisted during the anonymous
+     *      flow.
+     *
+     * Returns the number of subscription + order rows that were re-attributed.
+     */
+    public function claimVatlyCustomer(string $vatlyCustomerId): int
+    {
+        app(Vatly::class)
+            ->customers()
+            ->attribute($vatlyCustomerId, (string) $this->getKey());
+
+        $this->vatly_id = $vatlyCustomerId;
+        $this->save();
+
+        $ownerAttrs = [
+            'owner_type' => $this->getMorphClass(),
+            'owner_id' => $this->getKey(),
+        ];
+
+        $subscriptions = Subscription::query()
+            ->whereNull('owner_id')
+            ->where('customer_id', $vatlyCustomerId)
+            ->update($ownerAttrs);
+
+        $orders = Order::query()
+            ->whereNull('owner_id')
+            ->where('customer_id', $vatlyCustomerId)
+            ->update($ownerAttrs);
+
+        return $subscriptions + $orders;
+    }
+
+    /**
+     * Claim an anonymous Vatly customer on the checkout-success redirect back.
+     *
+     * Reads the checkout id from the request query — Vatly substitutes it into
+     * the redirect URL via the `{CHECKOUT_ID}` placeholder you set when building
+     * the checkout (e.g. `route('vatly.return').'?checkout_id={CHECKOUT_ID}'`) —
+     * resolves the checkout's Vatly customer id, and, if a customer is attached,
+     * runs {@see self::claimVatlyCustomer()} to bind it and re-attribute this
+     * entity's previously-anonymous orders and subscriptions.
+     *
+     * Multi-tab safe by construction: each tab carries its own checkout id in
+     * its own redirect URL, so concurrent checkouts resolve independently —
+     * there is no shared session/cookie carrier whose last write wins.
+     *
+     * Returns whether a claim happened. Returns false (without throwing) for a
+     * missing / unknown checkout id, or a checkout with no customer yet — so it
+     * is safe to call unconditionally on the return route. A cross-host conflict
+     * (the id already bound to a different customer) still throws
+     * {@see CustomerAlreadyBoundException}.
+     *
+     * Out of scope: buyers who never return via the redirect link (closed tab,
+     * different device). That is the email-recovery story, handled separately.
+     */
+    public function claimVatlyCustomerFromReturn(Request $request, string $key = 'checkout_id'): bool
+    {
+        $checkoutId = $request->query($key);
+
+        if (! is_string($checkoutId) || $checkoutId === '') {
+            return false;
+        }
+
+        $customerId = app(Vatly::class)->customerIdFromCheckout($checkoutId);
+
+        if ($customerId === null) {
+            return false;
+        }
+
+        $this->claimVatlyCustomer($customerId);
+
+        return true;
+    }
+
+    // --- Static finders ---
+
+    public static function findBillable(string $vatlyId): ?static
+    {
+        return static::where('vatly_id', $vatlyId)->first();
+    }
+
+    public static function findBillableOrFail(string $vatlyId): static
+    {
+        return static::where('vatly_id', $vatlyId)->firstOrFail();
+    }
+}

--- a/src/VatlyBillable.php
+++ b/src/VatlyBillable.php
@@ -18,16 +18,28 @@ use Vatly\Laravel\Models\Refund;
 use Vatly\Laravel\Models\Subscription;
 
 /**
- * Vatly billing capability for an Eloquent model.
+ * Vatly billing capability under `vatly*`-prefixed names — for running Vatly
+ * *beside* another Cashier-style biller on the same Eloquent model.
  *
- * Apply on your User/Tenant model when Vatly is your billing integration. The
- * trait exposes `subscribe`, `subscription`, `checkout`, `createAsVatlyCustomer`,
- * … — composing fluent's framework-agnostic surface with Eloquent queries.
+ * Laravel Cashier (Stripe and Paddle) and Lemon Squeezy for Laravel each ship a
+ * `Billable` trait that defines `subscribed()`, `subscription()`,
+ * `subscriptions()` and `checkout()` (Paddle and Lemon Squeezy also `subscribe()`;
+ * Lemon Squeezy also `orders()`). PHP forbids two traits defining the same method
+ * on one class, so {@see Billable} cannot sit next to one of those. This trait
+ * exposes the identical Vatly surface as `vatlySubscribed()`,
+ * `vatlySubscription()`, `vatlySubscribe()`, `vatlyCheckout()`, `vatlyOrder()` and
+ * the `vatly*` relations — so both billers coexist with no trait aliasing.
  *
- * Running Vatly *beside* another Cashier-style biller (Laravel Cashier for Stripe
- * or Paddle, or Lemon Squeezy for Laravel) on the same model? Use
- * {@see VatlyBillable} instead — it exposes the same capability under
- * `vatly*`-prefixed names so the two traits don't collide.
+ * Crucially, the state readers (`vatlySubscribed()` / `vatlySubscription()`) query
+ * this trait's own `vatlySubscriptions()` relation, never an unprefixed
+ * `subscriptions()` that the other biller owns — so there is no cross-wiring.
+ *
+ * Customer identity and claim helpers (`createAsVatlyCustomer()`,
+ * `claimVatlyCustomerFromReturn()`, `findBillable()`, …) already carry the Vatly
+ * name, don't collide, and are shared verbatim with {@see Billable} via
+ * {@see ManagesVatlyCustomer}.
+ *
+ * If Vatly is your *only* biller, use {@see Billable} (unprefixed) instead.
  *
  * @property string|null $vatly_id
  * @property string|null $email
@@ -38,16 +50,16 @@ use Vatly\Laravel\Models\Subscription;
  * @method mixed getKey()
  * @method string getMorphClass()
  */
-trait Billable
+trait VatlyBillable
 {
     use ManagesVatlyCustomer;
 
-    // --- Eloquent relations (Laravel-specific) ---
+    // --- Eloquent relations (vatly*-prefixed to avoid collisions) ---
 
     /**
      * @return MorphMany<Subscription>
      */
-    public function subscriptions(): MorphMany
+    public function vatlySubscriptions(): MorphMany
     {
         return $this->morphMany(Subscription::class, 'owner')->orderByDesc('created_at');
     }
@@ -55,7 +67,7 @@ trait Billable
     /**
      * @return MorphMany<Order>
      */
-    public function orders(): MorphMany
+    public function vatlyOrders(): MorphMany
     {
         return $this->morphMany(Order::class, 'owner')->orderByDesc('created_at');
     }
@@ -63,7 +75,7 @@ trait Billable
     /**
      * @return MorphMany<Refund>
      */
-    public function refunds(): MorphMany
+    public function vatlyRefunds(): MorphMany
     {
         return $this->morphMany(Refund::class, 'owner')->orderByDesc('created_at');
     }
@@ -71,37 +83,37 @@ trait Billable
     /**
      * @return MorphMany<Chargeback>
      */
-    public function chargebacks(): MorphMany
+    public function vatlyChargebacks(): MorphMany
     {
         return $this->morphMany(Chargeback::class, 'owner')->orderByDesc('created_at');
     }
 
-    // --- Subscription accessors ---
+    // --- Subscription accessors (vatly*-prefixed) ---
 
-    public function subscribe(): SubscriptionBuilder
+    public function vatlySubscribe(): SubscriptionBuilder
     {
         return app(Vatly::class)->subscriptionBuilder($this->customerProfile());
     }
 
-    public function subscribed(string $type = Subscription::DEFAULT_TYPE): bool
+    public function vatlySubscribed(string $type = Subscription::DEFAULT_TYPE): bool
     {
-        $subscription = $this->subscriptions()
+        $subscription = $this->vatlySubscriptions()
             ->where('type', $type)
             ->first();
 
         return $subscription !== null && $subscription->isActive();
     }
 
-    public function subscription(string $type = Subscription::DEFAULT_TYPE): ?SubscriptionHandle
+    public function vatlySubscription(string $type = Subscription::DEFAULT_TYPE): ?SubscriptionHandle
     {
-        $local = $this->subscriptions()
+        $local = $this->vatlySubscriptions()
             ->where('type', $type)
             ->first();
 
         return $local !== null ? app(Vatly::class)->subscription($local) : null;
     }
 
-    public function checkout(): CheckoutBuilder
+    public function vatlyCheckout(): CheckoutBuilder
     {
         return app(Vatly::class)->checkoutBuilder($this->customerProfile());
     }
@@ -109,9 +121,9 @@ trait Billable
     /**
      * @throws InvalidOrderException When no order with the given Vatly id exists for this owner.
      */
-    public function order(string $vatlyId): OrderHandle
+    public function vatlyOrder(string $vatlyId): OrderHandle
     {
-        $local = $this->orders()
+        $local = $this->vatlyOrders()
             ->where('vatly_id', $vatlyId)
             ->first();
 

--- a/tests/Fixtures/CoexistingUser.php
+++ b/tests/Fixtures/CoexistingUser.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Foundation\Auth\User as Authenticatable;
+use Vatly\Laravel\Billable;
+use Vatly\Laravel\VatlyBillable;
+
+/**
+ * Stand-in for another Cashier-style `Billable` trait (Laravel Cashier for
+ * Stripe/Paddle, or Lemon Squeezy for Laravel): it declares exactly the method
+ * names that would collide with Vatly's unprefixed {@see Billable}.
+ *
+ * The return values are deliberately distinct from Vatly's so a test can prove
+ * which trait a given call routes to.
+ */
+trait FakeForeignBillable
+{
+    public function subscriptions(): string
+    {
+        return 'foreign:subscriptions';
+    }
+
+    public function subscription(string $type = 'default'): string
+    {
+        return 'foreign:subscription';
+    }
+
+    public function subscribed(string $type = 'default'): bool
+    {
+        return true;
+    }
+
+    public function subscribe(): string
+    {
+        return 'foreign:subscribe';
+    }
+
+    public function checkout(): string
+    {
+        return 'foreign:checkout';
+    }
+
+    public function orders(): string
+    {
+        return 'foreign:orders';
+    }
+}
+
+/**
+ * A billable model that carries a foreign Cashier-style trait *and* Vatly's
+ * coexistence trait ({@see VatlyBillable}) at the same time — the exact
+ * side-by-side scenario.
+ *
+ * That this class loads at all is half the proof: PHP fatals on a trait method
+ * collision at class-definition time, so a green test suite means the two traits
+ * compose cleanly.
+ */
+class CoexistingUser extends Authenticatable
+{
+    use FakeForeignBillable;
+    use VatlyBillable;
+
+    protected $table = 'users';
+
+    protected $guarded = [];
+}

--- a/tests/VatlyBillableTraitTest.php
+++ b/tests/VatlyBillableTraitTest.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Laravel\Tests;
+
+use App\Models\CoexistingUser;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Vatly\Fluent\Builders\CheckoutBuilder;
+use Vatly\Fluent\Builders\SubscriptionBuilder;
+use Vatly\Fluent\CustomerProfile;
+use Vatly\Fluent\OrderHandle;
+use Vatly\Fluent\SubscriptionHandle;
+use Vatly\Laravel\Models\Order;
+use Vatly\Laravel\Models\Subscription;
+use Vatly\Laravel\VatlyBillable;
+
+/**
+ * Exercises {@see VatlyBillable} on a model that *also* carries a
+ * foreign Cashier-style `Billable` trait, proving the two coexist with no
+ * collision and without cross-wiring the state readers.
+ */
+class VatlyBillableTraitTest extends BaseTestCase
+{
+    use RefreshDatabase;
+
+    private function user(array $attrs = []): CoexistingUser
+    {
+        return CoexistingUser::create(array_merge([
+            'name' => 'Test User',
+            'email' => 'coexist+'.uniqid().'@example.test',
+            'password' => bcrypt('password'),
+            'vatly_id' => null,
+        ], $attrs));
+    }
+
+    private function activeVatlySubscription(CoexistingUser $user, string $type = 'default'): Subscription
+    {
+        return Subscription::create([
+            'owner_type' => $user->getMorphClass(),
+            'owner_id' => $user->getKey(),
+            'vatly_id' => 'subscription_abc',
+            'type' => $type,
+            'plan_id' => 'plan_basic',
+            'name' => 'Basic',
+            'quantity' => 1,
+            'testmode' => true,
+        ]);
+    }
+
+    public function test_the_two_billable_traits_compose_without_collision(): void
+    {
+        $user = $this->user();
+
+        // The foreign trait keeps the unprefixed names…
+        $this->assertSame('foreign:subscriptions', $user->subscriptions());
+        $this->assertSame('foreign:subscription', $user->subscription());
+        $this->assertSame('foreign:subscribe', $user->subscribe());
+        $this->assertSame('foreign:checkout', $user->checkout());
+        $this->assertSame('foreign:orders', $user->orders());
+        $this->assertTrue($user->subscribed());
+
+        // …while Vatly lives entirely under vatly* names.
+        $this->assertInstanceOf(SubscriptionBuilder::class, $user->vatlySubscribe());
+        $this->assertInstanceOf(CheckoutBuilder::class, $user->vatlyCheckout());
+        $this->assertInstanceOf(MorphMany::class, $user->vatlySubscriptions());
+        $this->assertInstanceOf(MorphMany::class, $user->vatlyOrders());
+    }
+
+    public function test_vatly_readers_are_independent_of_the_foreign_subscription_state(): void
+    {
+        $user = $this->user();
+
+        // No Vatly rows yet — vatlySubscribed() must run Vatly's own logic and
+        // return false, even though the foreign subscribed() returns true.
+        $this->assertTrue($user->subscribed());
+        $this->assertFalse($user->vatlySubscribed());
+        $this->assertNull($user->vatlySubscription());
+    }
+
+    public function test_vatly_subscribed_reads_the_prefixed_relation_not_the_foreign_one(): void
+    {
+        $user = $this->user();
+        $subscription = $this->activeVatlySubscription($user);
+
+        $this->assertTrue($user->vatlySubscribed());
+        $this->assertFalse($user->vatlySubscribed('team'));
+
+        $handle = $user->vatlySubscription();
+
+        $this->assertInstanceOf(SubscriptionHandle::class, $handle);
+        $this->assertSame('subscription_abc', $handle->getVatlyId());
+        $this->assertSame('plan_basic', $handle->getPlanId());
+        $this->assertTrue($handle->active());
+        $this->assertEquals($subscription->id, $handle->model()->getKey());
+
+        // The foreign reader is untouched — no cross-wiring through subscriptions().
+        $this->assertSame('foreign:subscription', $user->subscription());
+        $this->assertTrue($user->subscribed());
+    }
+
+    public function test_vatly_subscriptions_relation_returns_only_owned_rows(): void
+    {
+        $user = $this->user(['vatly_id' => 'customer_owned']);
+        $this->activeVatlySubscription($user);
+
+        // A subscription owned by nobody (anonymous flow) must not leak in.
+        Subscription::create([
+            'vatly_id' => 'subscription_orphan',
+            'customer_id' => 'cus_orphan',
+            'type' => 'default',
+            'plan_id' => 'plan_basic',
+            'name' => 'Basic',
+            'quantity' => 1,
+            'testmode' => true,
+        ]);
+
+        $this->assertCount(1, $user->vatlySubscriptions);
+        $this->assertSame('subscription_abc', $user->vatlySubscriptions->first()->getVatlyId());
+    }
+
+    public function test_vatly_order_resolves_through_the_prefixed_relation(): void
+    {
+        $user = $this->user();
+
+        Order::create([
+            'owner_type' => $user->getMorphClass(),
+            'owner_id' => $user->getKey(),
+            'vatly_id' => 'order_abc',
+            'status' => 'paid',
+            'total' => 9900,
+            'currency' => 'EUR',
+            'testmode' => true,
+        ]);
+
+        $handle = $user->vatlyOrder('order_abc');
+
+        $this->assertInstanceOf(OrderHandle::class, $handle);
+        $this->assertSame('order_abc', $handle->getVatlyId());
+
+        // The foreign relation is still its own thing.
+        $this->assertSame('foreign:orders', $user->orders());
+    }
+
+    public function test_shared_customer_helpers_are_available_on_the_coexistence_trait(): void
+    {
+        $user = $this->user([
+            'vatly_id' => 'customer_xyz',
+            'email' => 'sander@example.test',
+            'name' => 'Sander',
+        ]);
+
+        // Identity + profile (shared via ManagesVatlyCustomer).
+        $this->assertSame('customer_xyz', $user->vatlyId());
+        $this->assertTrue($user->hasVatlyId());
+        $profile = $user->customerProfile();
+        $this->assertInstanceOf(CustomerProfile::class, $profile);
+        $this->assertSame('customer_xyz', $profile->vatlyId);
+
+        // Static finders.
+        $found = CoexistingUser::findBillable('customer_xyz');
+        $this->assertNotNull($found);
+        $this->assertSame($user->getKey(), $found->getKey());
+
+        $this->expectException(ModelNotFoundException::class);
+        CoexistingUser::findBillableOrFail('customer_nonexistent');
+    }
+
+    public function test_claim_backfills_orphan_rows_on_the_coexistence_trait(): void
+    {
+        Subscription::create([
+            'vatly_id' => 'sub_anon',
+            'customer_id' => 'cus_anon',
+            'type' => 'default',
+            'plan_id' => 'plan_basic',
+            'name' => 'Basic',
+            'quantity' => 1,
+            'testmode' => true,
+        ]);
+        Order::create([
+            'vatly_id' => 'order_anon',
+            'customer_id' => 'cus_anon',
+            'status' => 'paid',
+            'total' => 9900,
+            'currency' => 'EUR',
+            'testmode' => true,
+        ]);
+
+        $user = $this->user(['vatly_id' => null]);
+
+        $claimed = $user->claimVatlyCustomer('cus_anon');
+
+        $this->assertSame(2, $claimed);
+        $this->assertSame('cus_anon', $user->fresh()->vatly_id);
+        $this->assertCount(1, $user->vatlySubscriptions);
+        $this->assertCount(1, $user->vatlyOrders);
+    }
+}


### PR DESCRIPTION
## What & why

Merchants typically run a new Merchant-of-Record provider **beside** their existing one for a while during migration. This PR makes Vatly drop in next to a Cashier-style biller, and documents both the greenfield "should I pick Vatly" question and the brownfield "how do I run it alongside" one.

### New API: `VatlyBillable` trait

All four packages (Vatly, Laravel Cashier for Stripe/Paddle, Lemon Squeezy) expose a `Billable` trait with the same method names (`subscribed()`, `subscription()`, `subscriptions()`, `checkout()`, …), so two can't sit on one model without a fatal trait-method collision.

- `Vatly\Laravel\VatlyBillable` exposes the full Vatly surface under `vatly*`-prefixed names (`vatlySubscribe()`, `vatlySubscribed()`, `vatlySubscription()`, `vatlyCheckout()`, `vatlyOrder()`, and the `vatly*` relations).
- It owns its **own** `vatlySubscriptions()` relation, so the state readers can't cross-wire to another provider's `subscriptions()` (the subtle "self-call trap" that makes naive trait aliasing fail silently).
- Shared customer identity / create / claim / finder logic moved into an internal `Concerns\ManagesVatlyCustomer` trait, composed by both `Billable` and `VatlyBillable` — one tested implementation, no drift.

`Billable`'s public API is **unchanged** — the existing `BillableTraitTest` passes untouched.

### Docs split by scenario

- **`docs/Comparison.md`** (new) — greenfield evaluation: how Vatly compares to the Cashier packages and Lemon Squeezy, what Merchant of Record changes for you (incl. the Stripe Managed Payments nuance), feature parity + roadmap, and a plain-`Billable` code sample.
- **`docs/Coexisting-with-Cashier.md`** — brownfield/migration mechanics: the trait collision, `VatlyBillable`, what doesn't collide (namespaced tables, separate webhook routes), the integration steps, the re-authorization migration flow, and a Cashier→Vatly cheat-sheet.
- **`README.md`** links to both and no longer names any competitor.

## Tests

`tests/VatlyBillableTraitTest.php` stacks a fake foreign `Billable` trait next to `VatlyBillable` on one model and asserts they compose with no collision and no cross-wiring (unprefixed calls route to the foreign trait, `vatly*` calls hit Vatly's tables).

- **120 tests / 353 assertions pass** (113 prior + 7 new)
- Pint: passed · PHPStan (level 6): no errors

## Reviewer notes

- Honest about roadmap gaps (coupons, license keys) with workarounds — phrased to inform, not oversell.
- Competitor names appear in the `docs/` comparison pages (the comparison is the point) but are intentionally kept out of the README.
- `VatlyBillable` is **new public API**: it'll want a changelog entry and the README install pin updated when the next alpha is tagged (left untagged per release/gating discipline).