### PR TITLE
docs: fix outdated MoR-compliance framing + shorten doc titles for nav

### DIFF
--- a/docs/Coexisting-with-Cashier.md
+++ b/docs/Coexisting-with-Cashier.md
@@ -1,6 +1,6 @@
 ![Vatly for Laravel](https://raw.githubusercontent.com/Vatly/vatly-laravel/main/art/banner.png)
 
-# Running Vatly next to your current billing provider
+# Side-by-side billing
 
 You don't swap a Merchant of Record overnight. The payment mandate for every active customer
 lives with your *current* seller of record, and the only way to move a customer is to have them

--- a/docs/Comparison.md
+++ b/docs/Comparison.md
@@ -1,6 +1,6 @@
 ![Vatly for Laravel](https://raw.githubusercontent.com/Vatly/vatly-laravel/main/art/banner.png)
 
-# How Vatly for Laravel compares
+# Comparison
 
 Picking the billing layer for a new Laravel app? If you've reached for Laravel Cashier
 before, Vatly will feel immediately familiar — a `Billable` trait, `subscribed()`,
@@ -58,25 +58,6 @@ Three things to take from this table:
    Lemon Squeezy and Stripe Managed Payments are US. Vatly is EEA-based, under EU jurisdiction —
    your customer data and your seller-of-record relationship stay in Europe. That, not the API,
    is the reason to choose one over another.
-
----
-
-## What a Merchant of Record actually changes for you
-
-The Laravel surfaces are nearly identical; the operational reality is not.
-
-**Without an MoR** (Cashier on classic Stripe Billing), *you* are the seller. You own VAT and
-sales-tax registration across every jurisdiction you cross a threshold in, the threshold
-monitoring itself, filing and remittance, compliant invoice generation, and the liability when
-it's wrong. Stripe Tax computes the right rate; everything around it is yours to build and run.
-
-**With Vatly** (a full MoR), the platform is the legal seller of record: it charges the
-customer, applies the correct tax, issues the invoice, remits to the authorities, and carries
-the compliance. You integrate subscriptions and gate features on `subscribed()` — that's the
-extent of what your app owns.
-
-For a new product selling into the EU and worldwide, that's the difference between launching
-now and standing up a tax-and-compliance function first.
 
 ---
 
@@ -158,17 +139,18 @@ Europe and the world, there's enough here to launch today.
 
 ## Why teams choose Vatly
 
-Three reasons come up again and again, and none of them are about the API:
+A Merchant of Record handles VAT, invoicing and tax remittance for you — and that part is now
+table stakes. Paddle, Lemon Squeezy, Stripe Managed Payments and Vatly all do it; on Stripe it's
+a flag on the request. So the real question isn't *whether* compliance is handled — it's whose
+entity you sell through:
 
-- **Europe-first, by design.** EEA-based, EU jurisdiction, customer data kept in Europe. No
-  dependency on US policy, and no awkward answers when an enterprise buyer asks where their data
-  and their seller of record sit.
-- **You never carry compliance.** Classic Stripe Billing leaves VAT registration, filing and
-  remittance with you; Vatly takes it. That's months of work and ongoing operational risk you
-  simply don't own.
+- **Europe-first, by design.** EEA-based, EU jurisdiction, customer data kept in Europe. The other
+  MoRs sit in the UK (Paddle) or the US (Lemon Squeezy, Stripe Managed Payments) — jurisdiction is
+  the one axis that genuinely separates them, and the reason Vatly exists.
+- **No exposure to US policy.** Your seller-of-record relationship and your customers' data stay
+  under EU law — a clean answer when an enterprise buyer, or your own board, asks where they sit.
 - **One familiar API.** The Cashier-shaped surface means there's little to learn and little to
-  rewrite if you ever did start elsewhere — the reasons to choose Vatly are about who carries the
-  compliance and where the entity sits, not about the code.
+  rewrite.
 
 > **You Just Ship.**
 


### PR DESCRIPTION
Follow-up to #53, addressing two pieces of review feedback on the new docs.

## 1. The "Stripe leaves you the compliance" framing is outdated

MoR-handles-compliance is now table stakes — Stripe Managed Payments enables it with a flag on the request, alongside Paddle and Lemon Squeezy. So the comparison no longer pitches Vatly's advantage as "we handle compliance, Stripe doesn't."

- **Removed** the `## What a Merchant of Record actually changes for you` section — devs reading these docs already know when to pick a MoR.
- **Reworded** `## Why teams choose Vatly` around the real differentiator (jurisdiction): a MoR handling VAT/invoicing/remittance is table stakes; the choice between MoRs is whose entity you sell through — and Vatly is the Europe-first one (the others are UK or US).

The at-a-glance table and the three MoR points (incl. the Stripe Managed Payments nuance) already carried the accurate picture and are unchanged.

## 2. Doc titles are too long — the docs site uses the page H1 as the nav label

- `# How Vatly for Laravel compares` → `# Comparison`
- `# Running Vatly next to your current billing provider` → `# Side-by-side billing`

## Notes

- Docs-only; no code change. Install pins remain at `v0.7.0-alpha.14`.
- Markdown validated (balanced fences / `<details>`, no orphaned separators).