### PR TITLE
docs: remove package banner from Comparison and Side-by-side pages

### DIFF
--- a/docs/Coexisting-with-Cashier.md
+++ b/docs/Coexisting-with-Cashier.md
@@ -1,5 +1,3 @@
-![Vatly for Laravel](https://raw.githubusercontent.com/Vatly/vatly-laravel/main/art/banner.png)
-
 # Side-by-side billing
 
 You don't swap a Merchant of Record overnight. The payment mandate for every active customer

--- a/docs/Comparison.md
+++ b/docs/Comparison.md
@@ -1,5 +1,3 @@
-![Vatly for Laravel](https://raw.githubusercontent.com/Vatly/vatly-laravel/main/art/banner.png)
-
 # Comparison
 
 Picking the billing layer for a new Laravel app? If you've reached for Laravel Cashier


### PR DESCRIPTION
The banner image belongs only on the Getting Started page (`docs/README.md`) — the other content docs (Subscriptions, Checkouts, …) start at their H1. The two pages added in #53/#54 carried it by mistake; this removes it so they match the convention. Docs-only.