### PR TITLE
docs: more descriptive page titles for the comparison + coexistence pages

### DIFF
--- a/docs/Coexisting-with-Cashier.md
+++ b/docs/Coexisting-with-Cashier.md
@@ -1,4 +1,4 @@
-# Side-by-side billing
+# Running Vatly next to another billing provider
 
 You don't swap a Merchant of Record overnight. The payment mandate for every active customer
 lives with your *current* seller of record, and the only way to move a customer is to have them

--- a/docs/Comparison.md
+++ b/docs/Comparison.md
@@ -1,4 +1,4 @@
-# Comparison
+# Vs Cashier (Stripe, Paddle) & Lemon Squeezy
 
 Picking the billing layer for a new Laravel app? If you've reached for Laravel Cashier
 before, Vatly will feel immediately familiar — a `Billable` trait, `subscribed()`,


### PR DESCRIPTION
The docs site uses each page's H1 as its nav label. Make the two new pages descriptive again:
- `Comparison` → `Vs Cashier (Stripe, Paddle) & Lemon Squeezy`
- `Side-by-side billing` → `Running Vatly next to another billing provider`

Lemon Squeezy is grouped outside the Cashier parens since it isn't a Cashier package. README link text stays competitor-name-free (per the README naming rule); only the docs-site nav labels carry the names. Docs-only.