### PR TITLE
docs: reference the comparison + coexistence pages from Getting Started

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,10 @@
 
 Vatly Laravel provides a Cashier-like integration for [Vatly](https://vatly.com) billing in your Laravel application. It handles subscriptions, checkouts, customers, webhooks, and payment method updates.
 
+> **Evaluating Vatly, or moving from another biller?**
+> - [How Vatly compares to Cashier (Stripe, Paddle) & Lemon Squeezy](Comparison.md) — for a greenfield app.
+> - [Running Vatly next to another billing provider](Coexisting-with-Cashier.md) — run it alongside your current one and move customers over gradually.
+
 ## Requirements
 
 - PHP 8.3+


### PR DESCRIPTION
Adds a short pointer after the intro on the Getting Started page (docs/README.md) to the two pages — the comparison (for greenfield) and the coexistence/migration guide (for those on another provider). Docs-only.