### PR TITLE
docs: rename coexistence page to 'Migrating to Vatly'

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Full docs at [docs.vatly.com](https://docs.vatly.com). In this repo:
 - [Orders](docs/Orders.md)
 - [Webhooks](docs/Webhooks.md)
 - [How Vatly compares](docs/Comparison.md) — Vatly vs. other Laravel billing packages, for greenfield apps
-- [Running alongside another provider](docs/Coexisting-with-Cashier.md) — adding Vatly next to an existing Merchant of Record, side by side
+- [Migrating to Vatly](docs/Migrating-to-Vatly.md) — adding Vatly next to an existing Merchant of Record, side by side
 
 ## Requirements
 
@@ -80,7 +80,7 @@ Pin to an exact version during alpha — the API will change.
    }
    ```
 
-   Already running another billing provider and migrating gradually? Reach for the `VatlyBillable` trait instead — it exposes the same surface under `vatly*`-prefixed names, so Vatly sits beside your existing biller without a trait collision. See [Running alongside another provider](docs/Coexisting-with-Cashier.md).
+   Already running another billing provider and migrating gradually? Reach for the `VatlyBillable` trait instead — it exposes the same surface under `vatly*`-prefixed names, so Vatly sits beside your existing biller without a trait collision. See [Migrating to Vatly](docs/Migrating-to-Vatly.md).
 
 ## Usage
 

--- a/docs/Comparison.md
+++ b/docs/Comparison.md
@@ -14,7 +14,7 @@ Cashier-style packages you might otherwise reach for —
 [Lemon Squeezy for Laravel](https://github.com/lmsqueezy/laravel) — gaps included.
 
 > **Already running one of these in an existing app?** This page helps you choose. Once you
-> have, [Running alongside another provider](Coexisting-with-Cashier.md) shows how to add Vatly
+> have, [Migrating to Vatly](Migrating-to-Vatly.md) shows how to add Vatly
 > next to your current biller and migrate customers over gradually.
 
 ---
@@ -147,7 +147,7 @@ entity you sell through:
 
 - **Starting fresh** → [Getting started](README.md) wires up the trait, config, migrations and
   webhook in a few minutes.
-- **Already running another provider** → [Running alongside another provider](Coexisting-with-Cashier.md)
+- **Already running another provider** → [Migrating to Vatly](Migrating-to-Vatly.md)
   shows how to add Vatly beside your current biller and migrate customers over gradually.
 - **Reference** → [Configuration](configuration.md) · [Customers](Customers.md) · [Checkouts](Checkouts.md) · [Subscriptions](Subscriptions.md) · [Orders](Orders.md) · [Webhooks](Webhooks.md)
 

--- a/docs/Migrating-to-Vatly.md
+++ b/docs/Migrating-to-Vatly.md
@@ -1,4 +1,4 @@
-# Running Vatly next to another billing provider
+# Migrating to Vatly
 
 You don't swap a Merchant of Record overnight. The payment mandate for every active customer
 lives with your *current* seller of record, and the only way to move a customer is to have them

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@ Vatly Laravel provides a Cashier-like integration for [Vatly](https://vatly.com)
 
 > **Evaluating Vatly, or moving from another biller?**
 > - [How Vatly compares to Cashier (Stripe, Paddle) & Lemon Squeezy](Comparison.md) — for a greenfield app.
-> - [Running Vatly next to another billing provider](Coexisting-with-Cashier.md) — run it alongside your current one and move customers over gradually.
+> - [Migrating to Vatly](Migrating-to-Vatly.md) — run it alongside your current one and move customers over gradually.
 
 ## Requirements
 


### PR DESCRIPTION
Renames `docs/Coexisting-with-Cashier.md` → `docs/Migrating-to-Vatly.md` (git rename; history preserved) and retitles the H1 to **Migrating to Vatly**. The page is fundamentally a migration guide whose method is running side by side, so the goal-oriented title matches reader intent and pairs cleanly with the comparison page. All five inbound links updated (root README, Getting Started, Comparison). Docs-only.