### PR TITLE
Adopt vatly-fluent-php alpha.23: customer update + subscription.updated events

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,8 @@ Events available:
 - `Vatly\API\Webhooks\Events\RefundCompleted` / `RefundFailed` / `RefundCanceled` — each with full `taxSummary`; persisted to `vatly_refunds` (see below).
 - `Vatly\API\Webhooks\Events\SubscriptionStarted`
 - `Vatly\API\Webhooks\Events\SubscriptionBillingUpdated` — the stored mandate (`mandate_method` / `mandate_masked_identifier`) is refreshed.
+- `Vatly\API\Webhooks\Events\SubscriptionUpdated` — an **immediate** plan/price/interval/quantity change; the local subscription's `plan_id`, `name` and `quantity` are refreshed from the payload (price is not stored locally).
+- `Vatly\API\Webhooks\Events\SubscriptionUpdateScheduled` — a change **scheduled** for the next billing cycle; the local row is left unchanged (the change hasn't applied yet). Dispatched only, exposing the target values via a typed `scheduledUpdate` (`Vatly\API\Types\ScheduledSubscriptionUpdate`) so you can, e.g., warn the customer of an upcoming price change.
 - `Vatly\API\Webhooks\Events\SubscriptionResumed` — the stored end date is cleared.
 - `Vatly\API\Webhooks\Events\SubscriptionCanceledImmediately`
 - `Vatly\API\Webhooks\Events\SubscriptionCanceledWithGracePeriod`

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "illuminate/http": "^12.0|^13.0",
         "illuminate/routing": "^12.0|^13.0",
         "illuminate/support": "^12.0|^13.0",
-        "vatly/vatly-fluent-php": "^0.8.0-alpha.21"
+        "vatly/vatly-fluent-php": "^0.8.0-alpha.23"
     },
     "require-dev": {
         "larastan/larastan": "^3.9",

--- a/docs/Customers.md
+++ b/docs/Customers.md
@@ -32,6 +32,22 @@ $user->getVatlyId(); // string|null
 $customer = $user->asVatlyCustomer();
 ```
 
+## Updating customer identity
+
+Update the customer's `name` and/or `email` at Vatly (both optional — send
+whichever changed). Billing-address details (company name, tax id, street, …)
+are **not** editable here; send the customer through the hosted billing-update
+flow for those.
+
+```php
+$customer = $user->updateVatlyCustomer([
+    'name' => 'Jane Doe',
+    'email' => 'jane@example.com',
+]);
+```
+
+Throws `NoVatlyCustomerException` if the user has no Vatly customer yet.
+
 ## How it works
 
 The `vatly_id` column on your billable model stores the Vatly customer identifier. When you call `createAsVatlyCustomer()`, it:

--- a/docs/Webhooks.md
+++ b/docs/Webhooks.md
@@ -32,6 +32,8 @@ When a webhook is received, the driver's `LaravelEventDispatcher` forwards the t
 | --- | --- |
 | `SubscriptionStarted` | A `subscription.started` webhook is received |
 | `SubscriptionBillingUpdated` | A `subscription.billing_updated` webhook is received — the stored mandate is refreshed |
+| `SubscriptionUpdated` | A `subscription.updated` webhook is received — an immediate plan/price/interval/quantity change; the local `plan_id` / `name` / `quantity` are refreshed |
+| `SubscriptionUpdateScheduled` | A `subscription.update_scheduled` webhook is received — a change scheduled for the next cycle; dispatched only (no local change), target values in `scheduledUpdate` |
 | `SubscriptionResumed` | A `subscription.resumed` webhook is received — the stored end date is cleared |
 | `SubscriptionCanceledImmediately` | A `subscription.canceled_immediately` webhook is received |
 | `SubscriptionCanceledWithGracePeriod` | A `subscription.canceled_with_grace_period` webhook is received |

--- a/src/Concerns/ManagesVatlyCustomer.php
+++ b/src/Concerns/ManagesVatlyCustomer.php
@@ -128,6 +128,27 @@ trait ManagesVatlyCustomer
     }
 
     /**
+     * Update this entity's Vatly customer identity fields (`name`, `email`).
+     *
+     * Both are optional — pass whichever you want to change. Billing-address
+     * details (company name, tax id, street, …) are not editable here; send
+     * the customer through the hosted billing-update flow for those. The host ↔
+     * Vatly binding is unaffected.
+     *
+     * @param  array<string, mixed>  $attributes  Any of `name`, `email`.
+     *
+     * @throws NoVatlyCustomerException When this entity has no Vatly customer yet.
+     */
+    public function updateVatlyCustomer(array $attributes = []): Customer
+    {
+        if (! $this->hasVatlyId()) {
+            throw NoVatlyCustomerException::notYetCreated($this);
+        }
+
+        return app(Vatly::class)->customers()->update((string) $this->vatlyId(), $attributes);
+    }
+
+    /**
      * Claim an anonymous Vatly customer for this host entity.
      *
      * Use this on a user-signup hook when the user paid via guest checkout

--- a/tests/BillableTraitTest.php
+++ b/tests/BillableTraitTest.php
@@ -7,13 +7,18 @@ namespace Vatly\Laravel\Tests;
 use App\Models\User;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Mockery;
+use Vatly\API\Resources\Customer as ApiCustomer;
+use Vatly\API\VatlyApiClient;
 use Vatly\Fluent\Builders\CheckoutBuilder;
 use Vatly\Fluent\Builders\SubscriptionBuilder;
 use Vatly\Fluent\CustomerProfile;
+use Vatly\Fluent\CustomerService;
 use Vatly\Fluent\Exceptions\InvalidOrderException;
 use Vatly\Fluent\OrderHandle;
 use Vatly\Fluent\SubscriptionHandle;
 use Vatly\Fluent\Vatly;
+use Vatly\Laravel\Exceptions\NoVatlyCustomerException;
 use Vatly\Laravel\Models\Chargeback;
 use Vatly\Laravel\Models\Order;
 use Vatly\Laravel\Models\Refund;
@@ -313,5 +318,42 @@ class BillableTraitTest extends BaseTestCase
 
         $this->assertSame(0, $claimed);
         $this->assertSame('cus_unknown', $user->fresh()->vatly_id);
+    }
+
+    public function test_update_vatly_customer_delegates_to_the_customer_service(): void
+    {
+        $user = User::factory()->create(['vatly_id' => 'customer_xyz']);
+
+        $apiCustomer = new ApiCustomer(Mockery::mock(VatlyApiClient::class));
+        $apiCustomer->id = 'customer_xyz';
+        $apiCustomer->name = 'Renamed';
+        $apiCustomer->email = 'renamed@example.test';
+
+        $customers = Mockery::mock(CustomerService::class);
+        $customers->shouldReceive('update')
+            ->once()
+            ->with('customer_xyz', ['name' => 'Renamed', 'email' => 'renamed@example.test'])
+            ->andReturn($apiCustomer);
+
+        $vatly = Mockery::mock(Vatly::class);
+        $vatly->shouldReceive('customers')->andReturn($customers);
+        $this->app->instance(Vatly::class, $vatly);
+
+        $result = $user->updateVatlyCustomer([
+            'name' => 'Renamed',
+            'email' => 'renamed@example.test',
+        ]);
+
+        $this->assertSame($apiCustomer, $result);
+        $this->assertSame('Renamed', $result->name);
+    }
+
+    public function test_update_vatly_customer_throws_when_no_vatly_id(): void
+    {
+        $user = User::factory()->create(['vatly_id' => null]);
+
+        $this->expectException(NoVatlyCustomerException::class);
+
+        $user->updateVatlyCustomer(['name' => 'Whoever']);
     }
 }


### PR DESCRIPTION
Bumps `vatly/vatly-fluent-php` to `^0.8.0-alpha.23` (which pulls api-php alpha.24) and cascades the relevant deltas into the Laravel integration.

## Changes

- **Customer update** — new `updateVatlyCustomer(array $attributes)` on the `Billable` / `VatlyBillable` traits (shared `ManagesVatlyCustomer` concern), delegating to fluent's `CustomerService::update()`. Edits a customer's `name`/`email` at Vatly (both optional). Throws `NoVatlyCustomerException` when the model has no Vatly customer yet. Documented in `docs/Customers.md`.
- **Two new subscription webhook events** — flow with **no code change**:
  - `LaravelEventDispatcher` forwards every fluent event to Laravel's event bus, so `SubscriptionUpdated` and `SubscriptionUpdateScheduled` are dispatchable to listeners out of the box.
  - fluent's built-in `SyncSubscriptionOnUpdated` reaction persists the **immediate** `subscription.updated` change (plan/name/quantity) through the existing `EloquentSubscriptionRepository::update()`.
  - `subscription.update_scheduled` is dispatched-only (the change applies next cycle; no local mutation), exposing target values via a typed `scheduledUpdate`.
  - Documented in the README event list and `docs/Webhooks.md`.

## No-ops (for the record)

- Subscription `price`, webhook-endpoints CRUD, and catalog `create` all live on the raw api-php client (`$vatly->getApiClient()`), which this package already exposes — no new Laravel surface needed.

## Tests

`vendor/bin/phpunit` (122 tests) and `phpstan` are green. Adds `Billable::updateVatlyCustomer` delegation + no-customer-throws tests.

Next release tag would be `v0.7.0-alpha.17` (matching the repo's tag-only cadence).