### PR TITLE
docs: stronger comparison copy + fix Docus callouts and migration wording

### DIFF
--- a/docs/Comparison.md
+++ b/docs/Comparison.md
@@ -38,10 +38,11 @@ Cashier-style packages you might otherwise reach for —
 
 Two takeaways:
 
-1. **`laravel/cashier` runs on classic Stripe Billing, where *you're* the seller of record** and
-   own VAT registration, filing and remittance. Stripe has a real MoR too
-   ([Managed Payments](https://stripe.com/managed-payments)), and Cashier — actively maintained —
-   will likely support it before long. Being an MoR is table stakes now, not a Vatly-only edge.
+1. **With `laravel/cashier`, *you're* the seller of record.** It runs on classic Stripe Billing, so
+   you register for VAT, file, and remit in every market you sell into — the compliance and the
+   liability sit with your company. (Stripe's own Merchant-of-Record product,
+   [Managed Payments](https://stripe.com/managed-payments), is a separate, US-based service you'd
+   integrate instead — not the Cashier subscriptions you're building on.)
 2. **So the real difference between MoRs is jurisdiction.** Paddle is UK, Lemon Squeezy and Stripe
    are US, Vatly is EEA — your seller-of-record entity and customer data stay under EU law. That,
    not the API, is the reason to choose one over another.
@@ -126,10 +127,9 @@ Europe and the world, there's enough here to launch today.
 
 ## Why teams choose Vatly
 
-A Merchant of Record handles VAT, invoicing and tax remittance for you — and that part is now
-table stakes. Paddle, Lemon Squeezy, Stripe Managed Payments and Vatly all do it; on Stripe it's
-a flag on the request. So the real question isn't *whether* compliance is handled — it's whose
-entity you sell through:
+A Merchant of Record makes the tax burden disappear — it becomes the legal seller, so VAT,
+invoicing and remittance stop being your problem. The real question is *whose* entity you hand that
+to, and that's where Vatly stands apart:
 
 - **Europe-first, by design.** EEA-based, EU jurisdiction, customer data kept in Europe. The other
   MoRs sit in the UK (Paddle) or the US (Lemon Squeezy, Stripe Managed Payments) — jurisdiction is

--- a/docs/Migrating-to-Vatly.md
+++ b/docs/Migrating-to-Vatly.md
@@ -36,16 +36,14 @@ PHP does not let two traits define the same method on one class — you get a fa
 *"trait method collision"* the moment you write `use LemonSqueezyBillable, VatlyBillable;`. So you
 have to decide, deliberately, **which provider owns the unprefixed method names**.
 
-> [!TIP]
-> **The cleanest fix is often to not share a model at all.** None of these `Billable` traits is
+> **Tip — the cleanest fix is often to not share a model at all.** None of these `Billable` traits is
 > tied to `User` — they work on any Eloquent model (`Team`, `Account`, `Organization`, …), and
 > Vatly's records are polymorphic (`owner_type` / `owner_id`). If your app bills a model that
 > isn't already carrying a Cashier-style trait — or you can introduce one — put Vatly's `Billable`
 > there and the collision disappears entirely. When both providers genuinely must live on the
 > *same* model, read on.
 
-> [!IMPORTANT]
-> **The self-call trap.** Plain trait aliasing (`insteadof` / `as`) is *not* enough here, and it
+> **Important — the self-call trap.** Plain trait aliasing (`insteadof` / `as`) is *not* enough here, and it
 > fails quietly. Vatly's `subscription()` and `subscribed()` call `$this->subscriptions()`
 > internally. If you alias `subscriptions` to the legacy provider with `insteadof`, then
 > `vatlySubscription()` will read the *legacy* subscriptions table and silently return the wrong
@@ -116,7 +114,7 @@ php artisan vendor:publish --tag=vatly-billable-migrations
 php artisan migrate
 ```
 
-This adds the `vatly_id` column and the `vatly_*` tables. Your existing tables are untouched. Add
+This creates the `vatly_*` tables and adds one nullable `vatly_id` column to your billable model's table. It's purely additive — no existing column or data is changed. Add
 the Vatly credentials alongside your current ones in `.env`:
 
 ```env


### PR DESCRIPTION
Three doc-copy fixes (all sync to docs.vatly.com):

1. **Comparison — remove weak framing.** The 'being an MoR is table stakes now, not a Vatly-only edge' / 'Cashier will likely support it before long' copy conceded the argument on our own site. Rewrote to state plainly that `laravel/cashier` makes *you* the seller of record (Stripe Managed Payments noted as a separate US service), then pivot confidently to Vatly as the European MoR. Same in the 'Why teams choose Vatly' intro.
2. **Callouts render broken on Docus.** GitHub's `> [!TIP]` / `> [!IMPORTANT]` alerts show up as literal '!TIP' text on docs.vatly.com. Converted to plain bold-lead blockquotes that render correctly on both GitHub and the docs site.
3. **Migration wording accuracy.** 'Your existing tables are untouched' was false — adding `vatly_id` alters the billable model's table. Reworded to: purely additive, one nullable column.

Docs-only.