### PR TITLE
docs: neat Docus callouts (::tip / ::warning) in the migration guide

### DIFF
--- a/docs/Migrating-to-Vatly.md
+++ b/docs/Migrating-to-Vatly.md
@@ -36,20 +36,24 @@ PHP does not let two traits define the same method on one class — you get a fa
 *"trait method collision"* the moment you write `use LemonSqueezyBillable, VatlyBillable;`. So you
 have to decide, deliberately, **which provider owns the unprefixed method names**.
 
-> **Tip — the cleanest fix is often to not share a model at all.** None of these `Billable` traits is
-> tied to `User` — they work on any Eloquent model (`Team`, `Account`, `Organization`, …), and
-> Vatly's records are polymorphic (`owner_type` / `owner_id`). If your app bills a model that
-> isn't already carrying a Cashier-style trait — or you can introduce one — put Vatly's `Billable`
-> there and the collision disappears entirely. When both providers genuinely must live on the
-> *same* model, read on.
+::tip
+**The cleanest fix is often to not share a model at all.** None of these `Billable` traits is
+tied to `User` — they work on any Eloquent model (`Team`, `Account`, `Organization`, …), and
+Vatly's records are polymorphic (`owner_type` / `owner_id`). If your app bills a model that
+isn't already carrying a Cashier-style trait — or you can introduce one — put Vatly's `Billable`
+there and the collision disappears entirely. When both providers genuinely must live on the
+*same* model, read on.
+::
 
-> **Important — the self-call trap.** Plain trait aliasing (`insteadof` / `as`) is *not* enough here, and it
-> fails quietly. Vatly's `subscription()` and `subscribed()` call `$this->subscriptions()`
-> internally. If you alias `subscriptions` to the legacy provider with `insteadof`, then
-> `vatlySubscription()` will read the *legacy* subscriptions table and silently return the wrong
-> thing. Aliasing is safe only for the *builder* methods (`subscribe`, `checkout`) that don't
-> self-call a relation; the *state readers* (`subscription`, `subscribed`) need their relation to
-> stay wired to Vatly.
+::warning
+**The self-call trap.** Plain trait aliasing (`insteadof` / `as`) is *not* enough here, and it
+fails quietly. Vatly's `subscription()` and `subscribed()` call `$this->subscriptions()`
+internally. If you alias `subscriptions` to the legacy provider with `insteadof`, then
+`vatlySubscription()` will read the *legacy* subscriptions table and silently return the wrong
+thing. Aliasing is safe only for the *builder* methods (`subscribe`, `checkout`) that don't
+self-call a relation; the *state readers* (`subscription`, `subscribed`) need their relation to
+stay wired to Vatly.
+::
 
 Because of that trap, the recommended approach below uses Vatly's purpose-built `VatlyBillable`
 trait, which exposes the whole Vatly surface under `vatly*` names and owns its *own*


### PR DESCRIPTION
Follow-up to #63. Plain blockquotes looked flat on the docs site, so the two asides in the migration guide now use Docus/Nuxt UI Pro MDC callouts — `::tip` for the 'don't share a model' aside and `::warning` for the self-call trap — the same components the hand-written guides already use on docs.vatly.com.

Build-verified against vatly-docs: they render as proper coloured callout boxes with icons (amber warning box, green tip box), no literal `::` text, no build error.

Trade-off: `::tip`/`::warning` render as literal text in GitHub's raw markdown view (they're a Docus feature, not GitHub-flavored markdown). The docs site is the primary surface, so this is the right call; if you also want GitHub-native rendering, I can move the conversion into `transform-laravel-docs.mjs` (keep `[!TIP]` in source, emit `::tip`) instead. Docs-only.