### PR TITLE
docs: consistent Docus ::note/::warning callouts across all pages

### DIFF
--- a/docs/Comparison.md
+++ b/docs/Comparison.md
@@ -13,9 +13,11 @@ Cashier-style packages you might otherwise reach for —
 [Laravel Cashier (Paddle)](https://laravel.com/docs/12.x/cashier-paddle), and
 [Lemon Squeezy for Laravel](https://github.com/lmsqueezy/laravel) — gaps included.
 
-> **Already running one of these in an existing app?** This page helps you choose. Once you
-> have, [Migrating from Cashier](Migrating-to-Vatly.md) shows how to add Vatly
-> next to your current biller and migrate customers over gradually.
+::note
+**Already running one of these in an existing app?** This page helps you choose. Once you
+have, [Migrating from Cashier](Migrating-to-Vatly.md) shows how to add Vatly
+next to your current biller and migrate customers over gradually.
+::
 
 ---
 

--- a/docs/Customers.md
+++ b/docs/Customers.md
@@ -108,7 +108,9 @@ $user->claimVatlyCustomerFromReturn($request, 'cid'); // reads ?cid=…
 
 This is **multi-tab safe by construction**: each tab carries its own checkout id in its own redirect URL, so two checkouts in flight resolve independently — there is no shared carrier whose last write wins.
 
-> The checkout id travels in the URL, so it may also appear in the `Referer` header and your server logs. It is low-sensitivity — it only names a checkout the buyer just completed — but treat it like any URL parameter.
+::note
+The checkout id travels in the URL, so it may also appear in the `Referer` header and your server logs. It is low-sensitivity — it only names a checkout the buyer just completed — but treat it like any URL parameter.
+::
 
 Under the hood `claimVatlyCustomerFromReturn()` resolves the checkout's customer id via the Vatly API and then runs `claimVatlyCustomer()`, which:
 
@@ -120,7 +122,9 @@ The `order.paid` / `subscription.started` webhook usually lands *before* the buy
 
 If you already hold the `cus_…` by other means, you can still call `claimVatlyCustomer($vatlyCustomerId)` directly; it returns the number of rows re-attributed.
 
-> **Out of scope:** buyers who never come back via the redirect link (closed the tab, switched device). Recovering those is the email-based recovery story — a separate concern this helper does not cover.
+::note
+**Out of scope:** buyers who never come back via the redirect link (closed the tab, switched device). Recovering those is the email-based recovery story — a separate concern this helper does not cover.
+::
 
 Need the email / name on the customer to surface a "would you like to claim purchase X?" prompt at signup? Fetch the customer via the Vatly API:
 

--- a/docs/Migrating-to-Vatly.md
+++ b/docs/Migrating-to-Vatly.md
@@ -12,9 +12,11 @@ integration ([Stripe](https://laravel.com/docs/12.x/billing) /
 [Lemon Squeezy](https://github.com/lmsqueezy/laravel)): the one thing you have to resolve, the
 things that *don't* need resolving, and the step-by-step.
 
-> **Still deciding whether to switch?** Start with [How Vatly compares](Comparison.md) — the
-> side-by-side on the Merchant-of-Record model, features, and what's on the roadmap. This page
-> assumes you've decided to run Vatly alongside what you already have.
+::note
+**Still deciding whether to switch?** Start with [How Vatly compares](Comparison.md) — the
+side-by-side on the Merchant-of-Record model, features, and what's on the roadmap. This page
+assumes you've decided to run Vatly alongside what you already have.
+::
 
 ---
 
@@ -162,9 +164,11 @@ That's the whole integration step. Two things make it safe by construction:
   `findBillable()` — don't collide, so `VatlyBillable` and the standalone `Billable` share one
   tested implementation; a fix to the claim / re-attribution logic reaches both.
 
-> **Vatly is your only biller?** Use the plain `Billable` trait instead (`subscribe()`,
-> `subscribed()`, …) — see [Getting started](README.md). `VatlyBillable` exists purely for running
-> beside another provider.
+::note
+**Vatly is your only biller?** Use the plain `Billable` trait instead (`subscribe()`,
+`subscribed()`, …) — see [Getting started](README.md). `VatlyBillable` exists purely for running
+beside another provider.
+::
 
 <details>
 <summary>Under the hood — the equivalent hand-written concern</summary>

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,9 +4,12 @@
 
 Vatly Laravel provides a Cashier-like integration for [Vatly](https://vatly.com) billing in your Laravel application. It handles subscriptions, checkouts, customers, webhooks, and payment method updates.
 
-> **Evaluating Vatly, or moving from another biller?**
-> - [How Vatly compares to Cashier (Stripe, Paddle) & Lemon Squeezy](Comparison.md) — for a greenfield app.
-> - [Migrating from Cashier](Migrating-to-Vatly.md) — run it alongside your current one and move customers over gradually.
+::note
+**Evaluating Vatly, or moving from another biller?**
+
+- [How Vatly compares to Cashier (Stripe, Paddle) & Lemon Squeezy](Comparison.md) — for a greenfield app.
+- [Migrating from Cashier](Migrating-to-Vatly.md) — run it alongside your current one and move customers over gradually.
+::
 
 ## Requirements
 
@@ -20,7 +23,9 @@ Vatly Laravel provides a Cashier-like integration for [Vatly](https://vatly.com)
 composer require vatly/vatly-laravel:v0.2.0-alpha.1
 ```
 
-> **Note:** This is an alpha release. Pin to an exact version to avoid breaking changes.
+::warning
+This is an alpha release. Pin to an exact version to avoid breaking changes.
+::
 
 ## Configuration
 
@@ -51,7 +56,9 @@ VATLY_REDIRECT_URL_CANCELED=https://your-app.com/checkout/canceled
 | `redirect_url_success` | `VATLY_REDIRECT_URL_SUCCESS` | (required for checkouts) |
 | `redirect_url_canceled` | `VATLY_REDIRECT_URL_CANCELED` | (required for checkouts) |
 
-> **Note:** Testmode is automatically determined from your API key prefix. Keys starting with `test_` use testmode; keys starting with `live_` use production mode. No configuration needed.
+::note
+Testmode is automatically determined from your API key prefix. Keys starting with `test_` use testmode; keys starting with `live_` use production mode. No configuration needed.
+::
 
 ## Database setup
 


### PR DESCRIPTION
Audited every docs page for callout candidates (per request) and converted the note/aside blockquotes to Docus MDC callouts, so docs.vatly.com uses proper callout boxes consistently:

| Page | Was | Now |
|---|---|---|
| Getting Started | evaluate/migrate pointer | `::note` |
| Getting Started | 'alpha, pin version' | `::warning` |
| Getting Started | testmode auto-detect note | `::note` |
| Comparison | 'already running one of these' | `::note` |
| Migrating | 'still deciding' / 'only biller?' | `::note` ×2 |
| Customers | checkout-id-in-logs / out-of-scope | `::note` ×2 |

Kept `> **You Just Ship.**` as a blockquote (tagline pullquote, not a callout).

**Build-verified** against vatly-docs (npm ci + nuxi build): every callout renders as a proper box (blue info / amber warning with icons), the list-inside-callout on Getting Started renders as a real bulleted list, no literal `::` text, no build error. Same GitHub-raw trade-off as #64. Docs-only.