### PR TITLE
docs: GitHub-native alert syntax for callouts (renders on GitHub + docs site)

### DIFF
--- a/docs/Comparison.md
+++ b/docs/Comparison.md
@@ -13,11 +13,10 @@ Cashier-style packages you might otherwise reach for —
 [Laravel Cashier (Paddle)](https://laravel.com/docs/12.x/cashier-paddle), and
 [Lemon Squeezy for Laravel](https://github.com/lmsqueezy/laravel) — gaps included.
 
-::note
-**Already running one of these in an existing app?** This page helps you choose. Once you
-have, [Migrating from Cashier](Migrating-to-Vatly.md) shows how to add Vatly
-next to your current biller and migrate customers over gradually.
-::
+> [!NOTE]
+> **Already running one of these in an existing app?** This page helps you choose. Once you
+> have, [Migrating from Cashier](Migrating-to-Vatly.md) shows how to add Vatly
+> next to your current biller and migrate customers over gradually.
 
 ---
 

--- a/docs/Customers.md
+++ b/docs/Customers.md
@@ -108,9 +108,8 @@ $user->claimVatlyCustomerFromReturn($request, 'cid'); // reads ?cid=…
 
 This is **multi-tab safe by construction**: each tab carries its own checkout id in its own redirect URL, so two checkouts in flight resolve independently — there is no shared carrier whose last write wins.
 
-::note
-The checkout id travels in the URL, so it may also appear in the `Referer` header and your server logs. It is low-sensitivity — it only names a checkout the buyer just completed — but treat it like any URL parameter.
-::
+> [!NOTE]
+> The checkout id travels in the URL, so it may also appear in the `Referer` header and your server logs. It is low-sensitivity — it only names a checkout the buyer just completed — but treat it like any URL parameter.
 
 Under the hood `claimVatlyCustomerFromReturn()` resolves the checkout's customer id via the Vatly API and then runs `claimVatlyCustomer()`, which:
 
@@ -122,9 +121,8 @@ The `order.paid` / `subscription.started` webhook usually lands *before* the buy
 
 If you already hold the `cus_…` by other means, you can still call `claimVatlyCustomer($vatlyCustomerId)` directly; it returns the number of rows re-attributed.
 
-::note
-**Out of scope:** buyers who never come back via the redirect link (closed the tab, switched device). Recovering those is the email-based recovery story — a separate concern this helper does not cover.
-::
+> [!NOTE]
+> **Out of scope:** buyers who never come back via the redirect link (closed the tab, switched device). Recovering those is the email-based recovery story — a separate concern this helper does not cover.
 
 Need the email / name on the customer to surface a "would you like to claim purchase X?" prompt at signup? Fetch the customer via the Vatly API:
 

--- a/docs/Migrating-to-Vatly.md
+++ b/docs/Migrating-to-Vatly.md
@@ -12,11 +12,10 @@ integration ([Stripe](https://laravel.com/docs/12.x/billing) /
 [Lemon Squeezy](https://github.com/lmsqueezy/laravel)): the one thing you have to resolve, the
 things that *don't* need resolving, and the step-by-step.
 
-::note
-**Still deciding whether to switch?** Start with [How Vatly compares](Comparison.md) — the
-side-by-side on the Merchant-of-Record model, features, and what's on the roadmap. This page
-assumes you've decided to run Vatly alongside what you already have.
-::
+> [!NOTE]
+> **Still deciding whether to switch?** Start with [How Vatly compares](Comparison.md) — the
+> side-by-side on the Merchant-of-Record model, features, and what's on the roadmap. This page
+> assumes you've decided to run Vatly alongside what you already have.
 
 ---
 
@@ -38,24 +37,22 @@ PHP does not let two traits define the same method on one class — you get a fa
 *"trait method collision"* the moment you write `use LemonSqueezyBillable, VatlyBillable;`. So you
 have to decide, deliberately, **which provider owns the unprefixed method names**.
 
-::tip
-**The cleanest fix is often to not share a model at all.** None of these `Billable` traits is
-tied to `User` — they work on any Eloquent model (`Team`, `Account`, `Organization`, …), and
-Vatly's records are polymorphic (`owner_type` / `owner_id`). If your app bills a model that
-isn't already carrying a Cashier-style trait — or you can introduce one — put Vatly's `Billable`
-there and the collision disappears entirely. When both providers genuinely must live on the
-*same* model, read on.
-::
+> [!TIP]
+> **The cleanest fix is often to not share a model at all.** None of these `Billable` traits is
+> tied to `User` — they work on any Eloquent model (`Team`, `Account`, `Organization`, …), and
+> Vatly's records are polymorphic (`owner_type` / `owner_id`). If your app bills a model that
+> isn't already carrying a Cashier-style trait — or you can introduce one — put Vatly's `Billable`
+> there and the collision disappears entirely. When both providers genuinely must live on the
+> *same* model, read on.
 
-::warning
-**The self-call trap.** Plain trait aliasing (`insteadof` / `as`) is *not* enough here, and it
-fails quietly. Vatly's `subscription()` and `subscribed()` call `$this->subscriptions()`
-internally. If you alias `subscriptions` to the legacy provider with `insteadof`, then
-`vatlySubscription()` will read the *legacy* subscriptions table and silently return the wrong
-thing. Aliasing is safe only for the *builder* methods (`subscribe`, `checkout`) that don't
-self-call a relation; the *state readers* (`subscription`, `subscribed`) need their relation to
-stay wired to Vatly.
-::
+> [!WARNING]
+> **The self-call trap.** Plain trait aliasing (`insteadof` / `as`) is *not* enough here, and it
+> fails quietly. Vatly's `subscription()` and `subscribed()` call `$this->subscriptions()`
+> internally. If you alias `subscriptions` to the legacy provider with `insteadof`, then
+> `vatlySubscription()` will read the *legacy* subscriptions table and silently return the wrong
+> thing. Aliasing is safe only for the *builder* methods (`subscribe`, `checkout`) that don't
+> self-call a relation; the *state readers* (`subscription`, `subscribed`) need their relation to
+> stay wired to Vatly.
 
 Because of that trap, the recommended approach below uses Vatly's purpose-built `VatlyBillable`
 trait, which exposes the whole Vatly surface under `vatly*` names and owns its *own*
@@ -164,11 +161,10 @@ That's the whole integration step. Two things make it safe by construction:
   `findBillable()` — don't collide, so `VatlyBillable` and the standalone `Billable` share one
   tested implementation; a fix to the claim / re-attribution logic reaches both.
 
-::note
-**Vatly is your only biller?** Use the plain `Billable` trait instead (`subscribe()`,
-`subscribed()`, …) — see [Getting started](README.md). `VatlyBillable` exists purely for running
-beside another provider.
-::
+> [!NOTE]
+> **Vatly is your only biller?** Use the plain `Billable` trait instead (`subscribe()`,
+> `subscribed()`, …) — see [Getting started](README.md). `VatlyBillable` exists purely for running
+> beside another provider.
 
 <details>
 <summary>Under the hood — the equivalent hand-written concern</summary>

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,12 +4,11 @@
 
 Vatly Laravel provides a Cashier-like integration for [Vatly](https://vatly.com) billing in your Laravel application. It handles subscriptions, checkouts, customers, webhooks, and payment method updates.
 
-::note
-**Evaluating Vatly, or moving from another biller?**
-
-- [How Vatly compares to Cashier (Stripe, Paddle) & Lemon Squeezy](Comparison.md) — for a greenfield app.
-- [Migrating from Cashier](Migrating-to-Vatly.md) — run it alongside your current one and move customers over gradually.
-::
+> [!NOTE]
+> **Evaluating Vatly, or moving from another biller?**
+>
+> - [How Vatly compares to Cashier (Stripe, Paddle) & Lemon Squeezy](Comparison.md) — for a greenfield app.
+> - [Migrating from Cashier](Migrating-to-Vatly.md) — run it alongside your current one and move customers over gradually.
 
 ## Requirements
 
@@ -23,9 +22,8 @@ Vatly Laravel provides a Cashier-like integration for [Vatly](https://vatly.com)
 composer require vatly/vatly-laravel:v0.2.0-alpha.1
 ```
 
-::warning
-This is an alpha release. Pin to an exact version to avoid breaking changes.
-::
+> [!WARNING]
+> This is an alpha release. Pin to an exact version to avoid breaking changes.
 
 ## Configuration
 
@@ -56,9 +54,8 @@ VATLY_REDIRECT_URL_CANCELED=https://your-app.com/checkout/canceled
 | `redirect_url_success` | `VATLY_REDIRECT_URL_SUCCESS` | (required for checkouts) |
 | `redirect_url_canceled` | `VATLY_REDIRECT_URL_CANCELED` | (required for checkouts) |
 
-::note
-Testmode is automatically determined from your API key prefix. Keys starting with `test_` use testmode; keys starting with `live_` use production mode. No configuration needed.
-::
+> [!NOTE]
+> Testmode is automatically determined from your API key prefix. Keys starting with `test_` use testmode; keys starting with `live_` use production mode. No configuration needed.
 
 ## Database setup
 


### PR DESCRIPTION
Flips the `::note`/`::tip`/`::warning` MDC callouts (from #64/#65) back to GitHub alert blockquotes — `> [!NOTE]` / `[!TIP]` / `[!WARNING]`.

Paired with **vatly-docs#47**, which teaches the sync transform to convert `[!NOTE]`→`::note` etc. Net result: callouts render natively on **github.com** (raw markdown) *and* as proper callout boxes on **docs.vatly.com** — no more trade-off.

10 callouts across 4 pages (7 NOTE, 1 TIP, 2 WARNING). Build-verified end-to-end against the patched transform.

⚠️ Merge order: land **vatly-docs#47 first**, then this — so the transform is ready when the sync fires. Docs-only.