### PR TITLE
docs: bump install pins to v0.7.0-alpha.17

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Full docs at [docs.vatly.com](https://docs.vatly.com). In this repo:
 ## Installation
 
 ```bash
-composer require vatly/vatly-laravel:v0.7.0-alpha.14
+composer require vatly/vatly-laravel:v0.7.0-alpha.17
 ```
 
 Pin to an exact version during alpha — the API will change.

--- a/docs/Migrating-to-Vatly.md
+++ b/docs/Migrating-to-Vatly.md
@@ -109,7 +109,7 @@ code you have to think about is the trait.
 ### 1. Install and migrate
 
 ```bash
-composer require vatly/vatly-laravel:v0.7.0-alpha.14
+composer require vatly/vatly-laravel:v0.7.0-alpha.17
 
 php artisan vendor:publish --tag=vatly-config
 php artisan vendor:publish --tag=vatly-migrations

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,7 +19,7 @@ Vatly Laravel provides a Cashier-like integration for [Vatly](https://vatly.com)
 ## Installation
 
 ```bash
-composer require vatly/vatly-laravel:v0.2.0-alpha.1
+composer require vatly/vatly-laravel:v0.7.0-alpha.17
 ```
 
 > [!WARNING]


### PR DESCRIPTION
Aligns all `composer require` pins with the latest tag. docs/README.md was pinned at `v0.2.0-alpha.1` (15 releases stale); the root README and migration guide were at alpha.14. Docs-only.